### PR TITLE
Fix (UI): Correct Zoom Button Order

### DIFF
--- a/components/kanban/ZoomAdjustment.vue
+++ b/components/kanban/ZoomAdjustment.vue
@@ -24,12 +24,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <template #trigger>
         <button
           class="bg-elevation-1 bg-elevation-2-hover transition-button border-elevation-2 rounded-l-2xl border-r px-3.5 py-2"
-          @click="increaseZoomLevel"
+          @click="decreaseZoomLevel"
         >
-          <MagnifyingGlassPlusIcon class="size-5" />
+          <MagnifyingGlassMinusIcon class="size-5" />
         </button>
       </template>
-      <template #content> {{ $t("components.kanban.zoomAdjustment.increaseLevel") }} </template>
+      <template #content> {{ $t("components.kanban.zoomAdjustment.decreaseLevel") }} </template>
     </Tooltip>
     <Tooltip direction="top">
       <template #trigger>
@@ -46,13 +46,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <template #trigger>
         <button
           class="bg-elevation-1 bg-elevation-2-hover transition-button border-elevation-2 rounded-r-2xl border-l px-3.5 py-2"
-          @click="decreaseZoomLevel"
+          @click="increaseZoomLevel"
         >
-          <MagnifyingGlassMinusIcon class="size-5" />
+          <MagnifyingGlassPlusIcon class="size-5" />
         </button>
       </template>
-      <template #content> {{ $t("components.kanban.zoomAdjustment.decreaseLevel") }} </template>
+      <template #content> {{ $t("components.kanban.zoomAdjustment.increaseLevel") }} </template>
     </Tooltip>
+    
   </div>
 </template>
 

--- a/components/kanban/ZoomAdjustment.vue
+++ b/components/kanban/ZoomAdjustment.vue
@@ -53,7 +53,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       </template>
       <template #content> {{ $t("components.kanban.zoomAdjustment.increaseLevel") }} </template>
     </Tooltip>
-    
   </div>
 </template>
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2024 trobonox <hello@trobo.dev>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Please describe your changes
* What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Reorders the buttons for the zoom adjustment such that decreasing zoom is placed on the left and increasing zoom is placed on the right.

![Screenshot_20241117_153617](https://github.com/user-attachments/assets/83aa88a2-6380-4755-a7ee-7b2f6063495f)

* Describe what your code exactly does and if it affects any other part of the code in any way (especially check for breaking changes)

Swaps the order of the nodes within the `ZoomAdjustment` component and adjusts the corresponding CSS classes so borders render properly.

Fixes #723 