### PR TITLE
Added translation string for tag placeholder text

### DIFF
--- a/components/modal/EditCard.vue
+++ b/components/modal/EditCard.vue
@@ -461,7 +461,7 @@ limitations under the License.
               v-model="tag"
               :tags="tags"
               :autocomplete-items="filteredItems"
-              placeholder="Add tag..."
+              :placeholder="$t('modals.editCard.tagInputPlaceholder')"
               @tags-changed="updateTags"
               @before-adding-tag="beforeTagAdd"
             />

--- a/locales/en.json
+++ b/locales/en.json
@@ -203,6 +203,7 @@
       "taskAdd": "Add Task",
       "newTaskPlaceholder": "Enter a task...",
       "tagsTitle": "Tags",
+      "tagInputPlaceholder": "Add tag...",
       "tagsEdit": "Edit Global Tags"
     },
     "help": {


### PR DESCRIPTION
The "Add tag..." placeholder text in card modal was previously hard-coded, now it's a translation string that can be added to locale files (for now it's only present in `en.json`)