### PR TITLE
Disabling animations disables tooltip animation, too

### DIFF
--- a/components/Dropdown.vue
+++ b/components/Dropdown.vue
@@ -27,7 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     <DropdownMenuPortal to=".default-layout">
       <DropdownMenuContent
         :align="align"
-        class="bg-primary-darker border-elevation-1 z-[99999] min-w-[100px] rounded-md border p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] outline-none will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade"
+        :class="classes"
         :side-offset="sideOffset"
       >
         <slot name="content" />
@@ -47,4 +47,13 @@ withDefaults(
     sideOffset: 5,
   }
 );
+
+const store = useTauriStore().store;
+let classes =
+  "bg-primary-darker border-elevation-1 z-[99999] min-w-[100px] rounded-md border p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] outline-none will-change-[opacity,transform]";
+const animationsEnabled = await store.get("animationsEnabled");
+if (animationsEnabled !== false) {
+  classes +=
+    "  data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade";
+}
 </script>

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -33,9 +33,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       </ComboboxTrigger>
     </ComboboxAnchor>
 
-    <ComboboxContent
-      class="bg-elevation-1 absolute z-10 mt-2 w-full min-w-[160px] overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade"
-    >
+    <ComboboxContent :class="tooltipClass">
       <ComboboxViewport class="p-[5px]">
         <ComboboxEmpty
           class="text-elevation-3 py-2 text-center text-xs font-medium"
@@ -75,6 +73,16 @@ const currentLocale = computed(() => {
 const setLang = (newLocale: string) => {
   setLocale(newLocale);
 };
+
+const store = useTauriStore().store;
+
+let tooltipClass =
+  "bg-elevation-1 absolute z-10 mt-2 w-full min-w-[160px] overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform]";
+const animationsEnabled = await store.get("animationsEnabled");
+if (animationsEnabled !== false) {
+  tooltipClass +=
+    " data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade";
+}
 
 watch(selectedLocale, (newLocale) => {
   setLang(newLocale ?? "en");

--- a/components/Tooltip.vue
+++ b/components/Tooltip.vue
@@ -25,10 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         <slot name="trigger" />
       </TooltipTrigger>
       <TooltipPortal to=".default-layout">
-        <TooltipContent
-          :side="direction"
-          class="border-elevation-1 bg-primary-darker z-[999999999] select-none rounded-[4px] border px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity] data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade"
-        >
+        <TooltipContent :side="direction" :class="tooltipClass">
           <slot name="content" />
           <TooltipArrow class="fill-bg-primary-darker" :width="10" />
         </TooltipContent>
@@ -46,4 +43,14 @@ withDefaults(
     direction: "right",
   }
 );
+
+const store = useTauriStore().store;
+
+let tooltipClass =
+  "border-elevation-1 bg-primary-darker z-[999999999] select-none rounded-[4px] border px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]";
+const animationsEnabled = await store.get("animationsEnabled");
+if (animationsEnabled !== false) {
+  tooltipClass +=
+    " data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade";
+}
 </script>

--- a/components/kanban/Card.vue
+++ b/components/kanban/Card.vue
@@ -130,9 +130,7 @@ limitations under the License.
       </div>
     </ContextMenuTrigger>
     <ContextMenuPortal to=".default-layout">
-      <ContextMenuContent
-        class="bg-primary-darker border-elevation-1 z-[99999] min-w-[100px] rounded-md border p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] outline-none will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade"
-      >
+      <ContextMenuContent :class="contextMenuClass">
         <ContextMenuItem
           value="Edit Name"
           class="bg-elevation-2-hover flex w-full cursor-pointer flex-row items-center rounded-md px-4 py-1.5 pl-[25px]"
@@ -373,6 +371,14 @@ const cardTextColorDim = computed(() => {
 
   return "text-gray-300";
 });
+
+let contextMenuClass =
+  "bg-primary-darker border-elevation-1 z-[99999] min-w-[100px] rounded-md border p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] outline-none will-change-[opacity,transform]";
+const animationsEnabled = await store.get("animationsEnabled");
+if (animationsEnabled !== false) {
+  contextMenuClass +=
+    " data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade";
+}
 
 const getFormattedDueDate = computed(() => {
   if (!dueDate.value) return "";


### PR DESCRIPTION
# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Are your git commits signed with a valid GPG key? <!-- (This is a requirement for contributing to Kanri!) -->

### New Feature Submissions:
1. [x] Did you lint your code locally before submission?
2. [x] Did you test your feature thoroughly to ensure there are no bugs? <!-- (when unit/integration tests are not available, manual testing suffices) -->
3. [x] Does your feature introduce breaking changes? **No**

### Please describe your changes

Disabling animations via the settings does not disable the tooltip popup animating. These changes will make the tooltips appear immediately.