### PR TITLE
feat: Finer adjustment for zoom parameter

### DIFF
--- a/components/kanban/Card.vue
+++ b/components/kanban/Card.vue
@@ -299,51 +299,12 @@ const allTasksCompleted = computed(() => {
   return false; //default return
 });
 
-// New computed properties for scaling elements
-const zoomClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "zoom-down text-sm";
-    case 0:
-      return "zoom-normal";
-    case 1:
-      return "zoom-up text-xl";
-    case 2:
-      return "zoom-up-2x text-2xl";
-    default:
-      return "zoom-normal";
-  }
-});
+// Base classes; scaling handled by the parent column zoom
+const zoomClass = computed(() => "zoom-normal");
 
-const iconSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "size-3";
-    case 0:
-      return "size-4";
-    case 1:
-      return "size-5";
-    case 2:
-      return "size-8";
-    default:
-      return "size-4";
-  }
-});
+const iconSizeClass = computed(() => "size-4");
 
-const taskTextClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-xs";
-    case 0:
-      return "text-sm";
-    case 1:
-      return "text-base";
-    case 2:
-      return "text-lg";
-    default:
-      return "text-sm";
-  }
-});
+const taskTextClass = computed(() => "text-sm");
 
 const cardBackgroundColor = computed(() => {
   if (!props.card.color) return "bg-elevation-2";

--- a/components/kanban/Column.vue
+++ b/components/kanban/Column.vue
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       columnSizeClass,
       columnSpacingClass,
     ]"
+    :style="columnZoomStyle"
   >
     <div
       id="board-title"
@@ -212,6 +213,7 @@ import type { Ref } from "vue";
 
 import { applyDrag } from "@/utils/drag-n-drop";
 import emitter from "@/utils/emitter";
+import { migrateLegacyZoomValue } from "@/utils/zoom";
 import { PlusIcon, XMarkIcon } from "@heroicons/vue/24/solid";
 //@ts-expect-error, sadly this library does not have ts typings
 import { Container, Draggable } from "vue3-smooth-dnd";
@@ -256,6 +258,10 @@ const titleInput: Ref<HTMLInputElement | null> = ref(null);
 const newCardInput: Ref<HTMLInputElement | null> = ref(null);
 
 const cards = ref<Card[]>(props.cardsList);
+const zoomPercent = computed(() => migrateLegacyZoomValue(props.zoomLevel));
+const columnZoomStyle = computed(() => ({
+  zoom: `${zoomPercent.value / 100}`,
+}));
 const newCardName = ref("");
 const cardAddMode = ref(false);
 const cardAddModeAddToTopOfColumn = ref(false);
@@ -316,221 +322,41 @@ onMounted(() => {
   }
 });
 
-// enhanced scaling classes based on zoom level
-const titleTextClassZoom = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-md";
-    case 0:
-      return "text-lg";
-    case 1:
-      return "text-xl";
-    case 2:
-      return "text-2xl";
-    default:
-      return "";
-  }
-});
+// Base classes; actual scaling handled via CSS zoom on the container
+const titleTextClassZoom = computed(() => "text-lg");
 
-const columnSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "w-48";
-    case 0:
-      return "w-64";
-    case 1:
-      return "w-96";
-    case 2:
-      return "w-[560px]";
-    default:
-      return "";
-  }
-});
+const columnSizeClass = computed(() => "w-64");
 
-// new scaled classes for other elements
-const badgeSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-xs";
-    case 0:
-      return "text-xs";
-    case 1:
-      return "text-sm";
-    case 2:
-      return "text-base";
-    default:
-      return "text-xs";
-  }
-});
+// Base classes for elements inside the column
+const badgeSizeClass = computed(() => "text-xs");
 
-const inputSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-sm py-0.5";
-    case 0:
-      return "text-base py-1";
-    case 1:
-      return "text-lg py-1.5";
-    case 2:
-      return "text-xl py-2";
-    default:
-      return "text-base py-1";
-  }
-});
+const inputSizeClass = computed(() => "text-base py-1");
 
-const iconSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "size-4";
-    case 0:
-      return "size-4";
-    case 1:
-      return "size-5";
-    case 2:
-      return "size-6";
-    default:
-      return "size-4";
-  }
-});
+const iconSizeClass = computed(() => "size-4");
 
-const columnSpacingClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "p-1.5";
-    case 0:
-      return "p-2";
-    case 1:
-      return "p-3";
-    case 2:
-      return "p-4";
-    default:
-      return "p-2";
-  }
-});
+const columnSpacingClass = computed(() => "p-2");
 
 const containerSpacingClass = computed(() => {
   if (cards.value.length === 0) {
     return "p-6";
   }
 
-  switch (props.zoomLevel) {
-    case -1:
-      return "mt-1.5";
-    case 0:
-      return "mt-2";
-    case 1:
-      return "mt-3";
-    case 2:
-      return "mt-4";
-    default:
-      return "mt-2";
-  }
+  return "mt-2";
 });
 
-const cardSpacingClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "mb-1.5";
-    case 0:
-      return "mb-2";
-    case 1:
-      return "mb-3";
-    case 2:
-      return "mb-4";
-    default:
-      return "mb-2";
-  }
-});
+const cardSpacingClass = computed(() => "mb-2");
 
-const textAreaSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "h-10 text-sm";
-    case 0:
-      return "h-12 text-base";
-    case 1:
-      return "h-16 text-lg";
-    case 2:
-      return "h-20 text-xl";
-    default:
-      return "h-12 text-base";
-  }
-});
+const textAreaSizeClass = computed(() => "h-12 text-base");
 
-const buttonSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-sm px-1.5 py-0.5";
-    case 0:
-      return "text-base px-2 py-1";
-    case 1:
-      return "text-lg px-3 py-1.5";
-    case 2:
-      return "text-xl px-4 py-2";
-    default:
-      return "text-base px-2 py-1";
-  }
-});
+const buttonSizeClass = computed(() => "text-base px-2 py-1");
 
-const addCardFormSpacingClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "mt-1.5";
-    case 0:
-      return "mt-2";
-    case 1:
-      return "mt-3";
-    case 2:
-      return "mt-4";
-    default:
-      return "mt-2";
-  }
-});
+const addCardFormSpacingClass = computed(() => "mt-2");
 
-const addCardButtonSpacingClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "mt-1.5 py-0.5";
-    case 0:
-      return "mt-2 py-1";
-    case 1:
-      return "mt-3 py-1.5";
-    case 2:
-      return "mt-4 py-2";
-    default:
-      return "mt-2 py-1";
-  }
-});
+const addCardButtonSpacingClass = computed(() => "mt-2 py-1");
 
-const addCardIconSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "size-4";
-    case 0:
-      return "size-6";
-    case 1:
-      return "size-8";
-    case 2:
-      return "size-10";
-    default:
-      return "size-6";
-  }
-});
+const addCardIconSizeClass = computed(() => "size-6");
 
-const addCardTextSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "text-sm";
-    case 0:
-      return "text-base";
-    case 1:
-      return "text-lg";
-    case 2:
-      return "text-xl";
-    default:
-      return "text-base";
-  }
-});
+const addCardTextSizeClass = computed(() => "text-base");
 
 const fuzzyMatch = (input: string, str: string) => {
   const inputWords = input.toLowerCase().split(/\s+/);

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -173,6 +173,7 @@ import {
   trelloJsonSchema,
 } from "@/types/json-schemas";
 import emitter from "@/utils/emitter";
+import { migrateLegacyZoomValue } from "@/utils/zoom";
 import { ask, message, open, save } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { useI18n } from "vue-i18n";
@@ -344,7 +345,10 @@ const importFromKanriFull = async () => {
   store.set("pins", zodParsed.pins);
   store.set("colors", zodParsed.colors);
   store.set("activeTheme", zodParsed.activeTheme);
-  store.set("columnZoomLevel", zodParsed.columnZoomLevel);
+  store.set(
+    "columnZoomLevel",
+    migrateLegacyZoomValue(zodParsed.columnZoomLevel)
+  );
   store.set("boardSortingOption", zodParsed.boardSortingOption);
   store.set("savedCustomTheme", zodParsed.savedCustomTheme);
   store.set("lastInstalledVersion", zodParsed.lastInstalledVersion);
@@ -438,8 +442,11 @@ const importFromKanbanElectronFull = async () => {
   store.set("boards", convertedBoards);
   store.set("colors", zodParsed.colors);
   store.set("activeTheme", zodParsed.activeTheme);
-  if (zodParsed.columnZoomLevel) {
-    store.set("columnZoomLevel", zodParsed.columnZoomLevel);
+  if (zodParsed.columnZoomLevel != null) {
+    store.set(
+      "columnZoomLevel",
+      migrateLegacyZoomValue(zodParsed.columnZoomLevel)
+    );
   }
 
   await message(t("pages.import.importSuccessPartial"), { kind: "info" });

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -322,6 +322,7 @@ import type { Ref } from "vue";
 import { useTauriStore } from "@/stores/tauriStore";
 import { kanriThemeSchema } from "@/types/json-schemas";
 import emitter from "@/utils/emitter";
+import { migrateLegacyZoomValue } from "@/utils/zoom";
 import { catppuccin, dark, light } from "@/utils/themes";
 import {
   ArrowDownTrayIcon,
@@ -349,7 +350,7 @@ const themeEditorDisplayed = ref(false);
 const autoThemeEnabled = ref(false);
 const systemTheme = useDark();
 
-const columnZoomLevel = ref(0);
+const columnZoomLevel = ref(100);
 
 const autostartCheckbox = ref(false);
 const addToTopCheckbox = ref(false);
@@ -374,14 +375,11 @@ onMounted(async () => {
   }
   if (activeTheme.value === "custom") themeEditorDisplayed.value = true;
 
-  const columnZoom: null | number = await store.get("columnZoomLevel");
+  const columnZoomRaw = await store.get("columnZoomLevel");
+  const resolvedZoom = migrateLegacyZoomValue(columnZoomRaw);
 
-  if (columnZoom == null) {
-    await store.set("columnZoomLevel", 0);
-    columnZoomLevel.value = 0;
-  } else {
-    columnZoomLevel.value = columnZoom;
-  }
+  columnZoomLevel.value = resolvedZoom;
+  await store.set("columnZoomLevel", resolvedZoom);
 
   const autostartStatus = await isEnabled();
   switch (autostartStatus) {

--- a/types/json-schemas.ts
+++ b/types/json-schemas.ts
@@ -97,7 +97,7 @@ export const kanriJsonSchema = z.object({
   boardSortingOption: z.string().optional().nullable(),
   boards: z.array(kanriBoardSchema),
   colors: kanriThemeSchema,
-  columnZoomLevel: z.number().optional().nullable(),
+  columnZoomLevel: z.union([z.number(), z.string()]).optional().nullable(),
   lastInstalledVersion: z.string().optional().nullable(),
   savedCustomTheme: kanriThemeSchema.optional().nullable(),
   reverseSorting: z.boolean().optional().nullable(),
@@ -121,7 +121,7 @@ export const kanbanElectronJsonSchema = z.object({
   activeTheme: z.string(),
   boards: z.array(kanbanElectronBoardSchema),
   colors: kanriThemeSchema,
-  columnZoomLevel: z.string().optional(),
+  columnZoomLevel: z.union([z.string(), z.number()]).optional().nullable(),
 });
 
 export const trelloJsonSchema = z.object({

--- a/utils/zoom.ts
+++ b/utils/zoom.ts
@@ -1,0 +1,32 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2022-2025 trobonox <hello@trobo.dev>
+SPDX-License-Identifier: GPL-3.0-or-later */
+
+export const ZOOM_MIN = 10;
+export const ZOOM_MAX = 500;
+export const ZOOM_STEP = 10;
+
+export const clampZoom = (value: number): number => {
+  const rounded = Math.round(value);
+  if (Number.isNaN(rounded)) return ZOOM_MIN;
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, rounded));
+};
+
+export const migrateLegacyZoomValue = (value: unknown): number => {
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    if (value <= 2 && value >= -10) {
+      // legacy zoom stored as offsets (-1..2) representing 50% steps
+      return clampZoom(100 + value * 50);
+    }
+
+    return clampZoom(value);
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return clampZoom(parsed);
+    }
+  }
+
+  return 100;
+};


### PR DESCRIPTION
* components/kanban/ZoomAdjustment.vue:37 
Now drives the zoom as a real percentage: the +/- buttons step by 10, the centre badge toggles to a numeric input for manual entry (Esc cancels, Enter/blur saves), and a double-click still snaps back to 100%.

* utils/zoom.ts:4 
Centralizes min/max/step values plus a migrateLegacyZoomValue helper so every caller works with the new percent scale while transparently upgrading the old -1…2 data.

* pages/kanban/[id].vue:334 and pages/settings.vue:353 
Load & store zoom as 10–500%, migrate any legacy values on first load, and reuse the shared helpers for the keyboard and button handlers.

* components/kanban/Column.vue:260 and components/kanban/Card.vue:302 
Keep the existing Tailwind base classes but apply a CSS zoom on the column container, giving smooth 10% increments without the old step changes.

* pages/import.vue:348 and types/json-schemas.ts:100 
Accept both legacy and new exports, normalizing the zoom value during full/partial imports so stored data is always in percent.