### PR TITLE
feat: add sort in search bar

### DIFF
--- a/components/kanban/SearchBar.vue
+++ b/components/kanban/SearchBar.vue
@@ -157,6 +157,9 @@ watch(
     } else if (newValue.startsWith("description:")) {
       activeFilter.value = "description:";
       displayModel.value = newValue.replace("description:", "");
+    } else if (newValue.startsWith("sort:")) {
+      activeFilter.value = "sort:";
+      displayModel.value = newValue.replace("sort:", "");
     } else {
       displayModel.value = newValue;
       activeFilter.value = "";

--- a/components/kanban/SearchBar.vue
+++ b/components/kanban/SearchBar.vue
@@ -71,6 +71,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           <span>description: search by description</span>
           <span class="group/edit invisible group-hover/item:visible">+</span>
         </li>
+        <li
+          class="group/item bg-elevation-2-hover flex cursor-pointer items-center justify-between rounded-md p-1 py-1.5"
+          @mousedown="addFilter('sort:')"
+        >
+          <span>sort: sort by field (tags, dueDate)</span>
+          <span class="group/edit invisible group-hover/item:visible">+</span>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2025 trobonox <hello@trobo.dev>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Are your git commits signed with a valid GPG key? <!-- (This is a requirement for contributing to Kanri!) -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:
1. [x] Did you lint your code locally before submission? ***(only on the files that I modified)***
2. [x] Did you test your feature thoroughly to ensure there are no bugs? <!-- (when unit/integration tests are not available, manual testing suffices) -->
3. [x] Does your feature not introduce breaking changes?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- For changes regarding the UI and not utility functions etc., you can safely ignore this -->
* [ ] Have you written new tests for your core changes, as applicable? ***(not sure how I would write tests for this? open to suggestions)***
* [ ] Have you successfully run tests with your changes locally? ***(N/A)***

### Please describe your changes
* What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

  Feature:
  Introduces sorting by tags and dueDate.

* Describe what your code exactly does and if it affects any other part of the code in any way (especially check for breaking changes)

  Adds a "sort:" filter to the search bar, which accepts a comma-separated list of a permutation of any size from {"tags", "dueDate"}, where earlier fields have precedence. If there are multiple tags per card, they are sorted lexicographically. dueDates are sorted as such: lesser dueDate, greater dueDate, null dueDate, completed lesser dueDate, completed greater dueDate.

### Additional context
<!-- You can delete this if there is nothing you want to add -->

Since I mostly created this for self use, I haven't yet implemented additional features (directionality, other fields) as I am indifferent to the details of their implementation.