### PR TITLE
feat: improve task reordering UX with visible drag handle

### DIFF
--- a/components/modal/EditCard.vue
+++ b/components/modal/EditCard.vue
@@ -326,7 +326,7 @@ limitations under the License.
               >
                 <Container
                   drag-class="cursor-grabbing"
-                  drag-handle-selector=".task-drag"
+                  drag-handle-selector=".task-drag-handle"
                   lock-axis="y"
                   orientation="vertical"
                   @drop="onTaskDrop"
@@ -335,7 +335,6 @@ limitations under the License.
                   <Draggable
                     v-for="(task, index) in tasks"
                     :key="task.id"
-                    :class="draggingEnabled ? 'task-drag' : 'nomoredragging'"
                     :index="index"
                   >
                     <div
@@ -344,6 +343,10 @@ limitations under the License.
                       <div
                         class="flex w-full flex-row items-center justify-start gap-4"
                       >
+                        <PhDotsSixVertical
+                          v-if="!taskEditMode"
+                          class="task-drag-handle text-dim-2 size-4 shrink-0 cursor-grab"
+                        />
                         <CheckboxRoot
                           v-model:checked="task.finished"
                           class="bg-elevation-4 bg-elevation-2-hover border-elevation-5 flex size-5 shrink-0 appearance-none items-center justify-center rounded-[4px] border outline-none"
@@ -493,6 +496,7 @@ import { CheckIcon, PlusIcon, XMarkIcon } from "@heroicons/vue/24/solid";
 import {
   PhCalendar,
   PhCheck,
+  PhDotsSixVertical,
   PhPencilSimple,
   PhTrash,
   PhX,
@@ -584,8 +588,6 @@ const newTaskInput: Ref<HTMLInputElement | null> = ref(null);
 const currentlyEditingTaskIndex = ref(-1);
 const currentlyEditingTaskName = ref("");
 const taskEditMode = ref(false);
-
-const draggingEnabled = ref(true);
 
 const enableTitleEditing = () => {
   emitter.emit("modalPreventClickOutsideClose");
@@ -694,7 +696,6 @@ const enableTaskEditMode = (
   task: { finished: boolean; name: string }
 ) => {
   taskEditMode.value = true;
-  draggingEnabled.value = false;
   currentlyEditingTaskIndex.value = index;
   currentlyEditingTaskName.value = task.name;
 };
@@ -712,7 +713,6 @@ const updateTask = (index: number) => {
   currentlyEditingTaskIndex.value = -1;
   currentlyEditingTaskName.value = "";
   taskEditMode.value = false;
-  draggingEnabled.value = true;
 
   updateCardTasks();
 };


### PR DESCRIPTION
Add a grip icon (PhDotsSixVertical) to task items to make drag-and-drop reordering more discoverable. The handle:
- Provides clear visual affordance for dragging
- Limits drag interaction to the icon only (more intuitive)
- Shows cursor-grab on hover
- Hides during task editing mode

Also simplified code by removing redundant draggingEnabled logic.

<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2025 trobonox <hello@trobo.dev>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Are your git commits signed with a valid GPG key? <!-- (This is a requirement for contributing to Kanri!) -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:
1. [ ] Did you lint your code locally before submission?
2. [ ] Did you test your feature thoroughly to ensure there are no bugs? <!-- (when unit/integration tests are not available, manual testing suffices) -->
3. [ ] Does your feature introduce breaking changes?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- For changes regarding the UI and not utility functions etc., you can safely ignore this -->
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Please describe your changes
* What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
* Describe what your code exactly does and if it affects any other part of the code in any way (especially check for breaking changes)

### Additional context
<!-- You can delete this if there is nothing you want to add -->
