### PR TITLE
style: reduce layout shifts when entering editing mode

### DIFF
--- a/components/kanban/Column.vue
+++ b/components/kanban/Column.vue
@@ -36,7 +36,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     >
       <div v-if="!titleEditing" class="flex flex-row items-center gap-1.5">
         <h1
-          class="stop-text-overflow ml-1 font-bold"
+          class="stop-text-overflow ml-1 font-bold text-lg"
           @click="enableTitleEditing()"
         >
           {{ props.title }}
@@ -55,7 +55,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         v-focus
         :v-disable-spellcheck="settings.disableSpellcheck"
         :class="[
-          'bg-elevation-2 border-accent text-no-overflow mr-2 w-full rounded-sm border-2 border-dotted px-2 outline-none',
+          'bg-elevation-2 border-accent text-no-overflow -m-2 mr-2 w-full rounded-sm border-2 border-dotted px-2 outline-none font-bold text-lg',
           inputSizeClass,
         ]"
         maxlength="1000"
@@ -148,7 +148,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         v-focus
         v-resizable
         :class="[
-          'bg-elevation-2 border-accent-focus mb-2 overflow-hidden rounded-sm p-1 focus:border-2 focus:border-dotted focus:outline-none',
+          'bg-elevation-2 border-accent-focus border-2 border-transparent mb-2 overflow-hidden rounded-sm p-1 focus:border-dotted focus:outline-none',
           textAreaSizeClass,
         ]"
         maxlength="5000"

--- a/pages/kanban/[id].vue
+++ b/pages/kanban/[id].vue
@@ -110,7 +110,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         ref="boardTitleInput"
         v-model="boardContent.title"
         v-focus
-        class="bg-elevation-2 border-accent text-no-overflow mb-1 mr-2 h-12 w-min rounded-sm border-2 border-dotted px-2 text-4xl outline-none"
+        class="bg-elevation-2 border-accent text-no-overflow mb-1 mr-2 -ml-2 h-12 w-min rounded-sm border-2 border-dotted px-2 text-4xl outline-none font-bold text-2xl"
         maxlength="500"
         type="text"
         @blur="


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2025 trobonox <hello@trobo.dev>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Are your git commits signed with a valid GPG key? <!-- (This is a requirement for contributing to Kanri!) -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:
1. [x] Did you lint your code locally before submission?
2. [x] Did you test your feature thoroughly to ensure there are no bugs? <!-- (when unit/integration tests are not available, manual testing suffices) -->
3. [ ] Does your feature introduce breaking changes?

### Please describe your changes
* What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
*  * Previously, when focusing/unfocusing the new card textarea or clicking on card titles and the board title to edit them, a noticeable layout shift would occur due to different spacing and font styling of the static text element and the input element. I changed the spacing and font styling of the input boxes to reflect the static text as best I could (a minor shift of a few pixels on the x-axis still occurs, but otherwise, it looks much more consistent now)
* Describe what your code exactly does and if it affects any other part of the code in any way (especially check for breaking changes)
* * I added new Tailwind classes for the input boxes to change their spacing and positioning, as well as the font styling. This should not affect anything else.

### Additional context
<!-- You can delete this if there is nothing you want to add -->
<img width="537" height="431" alt="grafik" src="https://github.com/user-attachments/assets/3cc636e6-8860-4a3c-9b7c-5ef2d3d74b83" />
<img width="546" height="437" alt="grafik" src="https://github.com/user-attachments/assets/b2bdcce5-56d8-4478-bb60-cbc73156216a" />

