### PR TITLE
Fix: Use CSS `filter` to fix background blurring and brightness on Linux devices

### DIFF
--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
   <nav
-    class="border-elevation-1 bg-sidebar mr-8 flex h-screen flex-col items-center justify-between overflow-hidden border-r-2 px-8 pb-6 pt-5 shadow-md"
+    class="border-elevation-1 bg-sidebar z-10 mr-8 flex h-screen flex-col items-center justify-between overflow-hidden border-r-2 px-8 pb-6 pt-5 shadow-md"
   >
     <ModalNewBoard
       v-show="newBoardModalVisible"
@@ -143,10 +143,12 @@ const keyDownListener = (e: KeyboardEvent) => {
 
 <style scoped>
 .bg-sidebar {
-  background: radial-gradient(
-    circle at top left,
-    var(--elevation-1) 10%,
-    transparent
-  );
+  background:
+    radial-gradient(
+      circle at top left,
+      var(--elevation-1) 10%,
+      transparent
+    ),
+    var(--bg-primary);
 }
 </style>

--- a/pages/kanban/[id].vue
+++ b/pages/kanban/[id].vue
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>, PwshLab, tareqdayya -->
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>, PwshLab, tareqdayya, alexlalves -->
 <!-- -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <!--
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
-  <div v-if="boardContent">
+  <div v-if="boardContent" class="relative">
     <ModalCustomBackground
       v-if="bgImageLoaded"
       v-show="showCustomBgModal"
@@ -95,6 +95,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       @closeModal="allColumnCardsRemoveDialog.cancel()"
       @confirmAction="allColumnCardsRemoveDialog.confirm(true)"
     />
+
+    <div class="bg-custom pointer-events-none absolute inset-0" :style="cssVars" />
 
     <div class="absolute top-4 z-50 ml-8 w-[calc(100vw-112px)]">
       <h1
@@ -221,19 +223,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     <div
       id="kanban-cols-container"
       v-dragscroll:nochilddrag
-      :style="cssVars"
-      class="custom-scrollbar-horizontal bg-custom flex max-h-screen flex-col overflow-y-hidden"
+      class="custom-scrollbar-horizontal flex max-h-screen flex-col overflow-y-hidden"
     >
-      <div
-        class="h-full w-max min-w-full pt-28"
-        :style="{
-          '-webkit-backdrop-filter':
-            'blur(' + bgBlur + ') brightness(' + bgBrightness + ')',
-          'backdrop-filter':
-            'blur(' + bgBlur + ') brightness(' + bgBrightness + ')',
-          'pointer-events': 'none',
-        }"
-      >
+    <div class="pointer-events-none h-full w-max min-w-full pt-28">
         <div class="pointer-events-auto z-50 pl-8">
           <div class="pt-4">
             <Container
@@ -767,7 +759,10 @@ const getGhostParent = () => {
 }
 
 .bg-custom {
-  z-index: 1;
+  filter:
+    blur(var(--blur-intensity))
+    brightness(var(--bg-brightness));
+
   background-image: var(--bg-custom-image);
   background-repeat: no-repeat;
   background-size: cover;

--- a/pages/kanban/[id].vue
+++ b/pages/kanban/[id].vue
@@ -762,7 +762,8 @@ const getGhostParent = () => {
   filter:
     blur(var(--blur-intensity))
     brightness(var(--bg-brightness));
-
+    
+    transition: filter 0.5s cubic-bezier(0.17, 0.67, 0.83, 0.67);
   background-image: var(--bg-custom-image);
   background-repeat: no-repeat;
   background-size: cover;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 * @leherkom has a WIP PR concerning a different workaround strategy: https://github.com/kanriapp/kanri/pull/954
* [X] Are your git commits signed with a valid GPG key? 

### Please describe your changes
* What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
  * Changes how the kanban background image, and its effects, are rendered
    * Previously, the background was displayed within the `kanban-cols-container` and the div wholly above it was applying a blur/brightness effect via `backdrop-filter`. This _should_ be working on most PCs, given that this property is a year and a half old, but some issues regarding webview or hardware acceleration on Linux seem to break its functionality.
    * The solution was to instead make a "fake" background by using an absolutely positioned element. This element is placed before the kanban board elements as its background and we can apply the more broadly accepted `filter` CSS property instead.


* Describe what your code exactly does and if it affects any other part of the code in any way
  * There are very mild changes to other parts of the code:
    * The main div wrapping the kanban board was given a relative position;
    * The `--bg-brightness` `--bg-custom-image` `--blur-intensity` variables are only accessible to the fake background element now;
    * The sidebar was given its own background-color instead of relying on the background color of the default layout;
    * The sidebar was given its own z-index of 10;

### Checklist
1. [X] Did you lint your code locally before submission?
 * No new warnings or errors introduced
2. [X] Did you test your feature thoroughly to ensure there are no bugs? <!-- (when unit/integration tests are not available, manual testing suffices) -->
  * Tested (and built) on Kubuntu 26.04 LTS, where the previous `backdrop-filter` effects weren't working
4. [X] Does your feature introduce breaking changes?
 * Not as far as I'm aware, but adding a `z-index: 10` to the Sidebar _may_ have had introduced a side effect I could not find.

### Additional context
Addresses issue [Board background image - blur and brightness sliders do nothing #808](https://github.com/kanriapp/kanri/issues/808)

<details>
<summary>Screen shot of blurred and dimmed background working on test board in Kubuntu 26.04 LTS</summary>
<img width="1429" height="1159" alt="image" src="https://github.com/user-attachments/assets/d9fc8241-14c4-43be-91fb-fd0af1226339" />
</details>