### PR TITLE
feat: live-reload board when .kanri.dat changes on disk

### DIFF
--- a/plugins/kanriDatWatcher.client.ts
+++ b/plugins/kanriDatWatcher.client.ts
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Kanri is an offline Kanban board app made using Tauri and Nuxt.
+Copyright (C) 2022-2026 trobonox <hello@trobo.dev>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { listen } from "@tauri-apps/api/event";
+import { useTauriStore } from "@/stores/tauriStore";
+import { useBoardsStore } from "@/stores/boards";
+
+// Reload the board when an external writer (the kanri-bridge daemon) changes
+// .kanri.dat on disk. The Tauri backend watches the file and emits
+// `kanri-dat-changed`; here we refresh the LazyStore's cache from disk, then
+// reload via the existing forceReloadBoards action (no new loader).
+export default defineNuxtPlugin(() => {
+  listen("kanri-dat-changed", async () => {
+    const tauri = useTauriStore().store;
+    await tauri.reload();
+    await useBoardsStore().forceReloadBoards();
+    console.log("[kanri-bridge] .kanri.dat changed externally — reloaded boards");
+  });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -311,11 +311,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -490,7 +490,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -669,7 +669,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -682,7 +682,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "core-foundation",
  "libc",
 ]
@@ -907,7 +907,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.6.1",
  "libc",
  "objc2 0.6.2",
@@ -1123,6 +1123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1487,7 +1506,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1948,12 +1967,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -2081,6 +2120,7 @@ name = "kanri"
 version = "0.8.2"
 dependencies = [
  "ignore",
+ "notify",
  "serde",
  "serde_json",
  "tauri",
@@ -2103,9 +2143,29 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -2172,7 +2232,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -2277,6 +2337,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2313,7 +2385,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2349,7 +2421,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2361,6 +2433,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2440,7 +2531,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.6.1",
  "objc2 0.6.2",
  "objc2-core-foundation",
@@ -2453,7 +2544,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2 0.6.2",
 ]
@@ -2464,7 +2555,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "objc2-core-foundation",
 ]
 
@@ -2489,7 +2580,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -2501,7 +2592,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.6.1",
  "objc2 0.6.2",
  "objc2-core-foundation",
@@ -2513,7 +2604,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2525,7 +2616,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2538,7 +2629,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "objc2 0.6.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
@@ -2550,7 +2641,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91672909de8b1ce1c2252e95bbee8c1649c9ad9d14b9248b3d7b4c47903c47ad"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.6.1",
  "objc2 0.6.2",
  "objc2-app-kit",
@@ -3122,7 +3213,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3329,7 +3420,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3444,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3466,18 +3557,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3845,7 +3936,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "block2 0.6.1",
  "core-foundation",
  "core-graphics",
@@ -4203,7 +4294,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "log",
  "serde",
  "serde_json",
@@ -4442,7 +4533,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "pin-project-lite",
  "slab",
  "socket2",
@@ -4590,7 +4681,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5248,6 +5339,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5295,6 +5395,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5356,6 +5471,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5374,6 +5495,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5389,6 +5516,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5422,6 +5555,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5437,6 +5576,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5458,6 +5603,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5473,6 +5624,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ tauri-plugin-dialog = "2.6.0"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-fs = "2.4.2"
 tauri-plugin-opener = "2"
+notify = "6"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,9 +9,50 @@
     windows_subsystem = "windows"
 )]
 
-use tauri::Manager;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_window_state::StateFlags;
+
+// Watch the data store for external writes (from the kanri-bridge daemon) and
+// tell the frontend to reload. The daemon writes `.kanri.dat` atomically via
+// rename, which swaps the file's inode — so we watch the parent directory and
+// filter, never the file path itself. Bursts are debounced into one event.
+fn start_kanri_dat_watcher(app: &AppHandle) {
+    let Ok(dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let dat_name = std::ffi::OsString::from(".kanri.dat");
+    let handle = app.clone();
+    std::thread::spawn(move || {
+        let (tx, rx) = channel();
+        let Ok(mut watcher) = RecommendedWatcher::new(tx, notify::Config::default()) else {
+            return;
+        };
+        if watcher.watch(&dir, RecursiveMode::NonRecursive).is_err() {
+            return;
+        }
+        // `watcher` is held for the life of this loop; it drops (and the OS
+        // closes its fds) when the app exits and the channel closes.
+        loop {
+            match rx.recv() {
+                Ok(Ok(event)) => {
+                    if !event.paths.iter().any(|p| p.file_name() == Some(dat_name.as_os_str())) {
+                        continue;
+                    }
+                    // Debounce: swallow follow-up events until 150ms of quiet,
+                    // collapsing a burst of writes into a single reload.
+                    while rx.recv_timeout(Duration::from_millis(150)).is_ok() {}
+                    let _ = handle.emit("kanri-dat-changed", ());
+                }
+                Ok(Err(_)) => continue,
+                Err(_) => break,
+            }
+        }
+    });
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -55,6 +96,8 @@ pub fn run() {
                         let _ = window.set_focus();
                     }
                 }));
+
+            start_kanri_dat_watcher(app.handle());
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/tests/manual-watcher-test.md
+++ b/tests/manual-watcher-test.md
@@ -6,67 +6,124 @@ SPDX-License-Identifier: GPL-3.0-or-later
 # Manual test: `.kanri.dat` live-reload watcher
 
 The Tauri backend watches the data store and emits `kanri-dat-changed` when an
-external process (the [kanri-bridge](https://github.com/Iamcodio/IAC-023-kanri-bridge)
-daemon) writes `.kanri.dat`. The frontend reloads the board on that event, so
-changes appear live with no "Import board" click.
+external process — the [kanri-bridge](https://github.com/Iamcodio/IAC-023-kanri-bridge)
+daemon, which owns the store via an HTTP API on `127.0.0.1:7457` — writes
+`.kanri.dat`. The frontend reloads the board on that event, so changes appear
+live with no "Import board" click.
 
-A full Tauri UI test harness is out of scope; these are manual steps.
+A full automated Tauri UI harness is out of scope; these steps are manual.
+Each one is copy-paste; you should not need to pair with the agent.
 
-## Prerequisites
+---
 
-- A release build of this fork: `yarn install && yarn tauri build`
-  (or `yarn tauri dev` for a faster loop).
-- The kanri-bridge daemon built and runnable
-  (`cargo build --release` in the IAC-023-kanri-bridge repo).
-- Store path: `~/Library/Application Support/tech.trobonox.kanri/.kanri.dat`.
+## Setup (once)
 
-> Point the daemon at the **real** store only deliberately. For these tests you
-> can either let it use the default path (real store, with Kanri open) or run
-> Kanri against a test store by launching it with that data dir.
+**Store path** (shared by Kanri and the daemon):
+`~/Library/Application Support/tech.trobonox.kanri/.kanri.dat`
+
+These tests deliberately drive the **real** store so Kanri sees the writes.
+That's safe: the daemon takes a rolling backup before every write
+(`~/Library/Application Support/tech.iamcodio.kanri-bridge/backups/`). If you'd
+rather not touch real data, first create a throwaway board in Kanri to mutate.
+
+1. **Build + launch this patched Kanri** (from the fork checkout):
+   ```bash
+   corepack yarn install
+   corepack yarn generate
+   corepack yarn tauri build
+   open "src-tauri/target/release/bundle/macos/kanri.app"
+   ```
+   For a faster dev loop you can use `corepack yarn tauri dev` instead.
+
+2. **Build + run the kanri-bridge daemon** (from the IAC-023-kanri-bridge repo,
+   in a second terminal). It defaults to the real store path above:
+   ```bash
+   cargo build --release
+   ./target/release/kanri-bridge
+   ```
+   Leave it running. Health-check from a third terminal:
+   ```bash
+   curl -sf http://127.0.0.1:7457/healthz   # -> {"ok":true,...}
+   ```
+
+3. **Grab a board id + card id** to target. In Kanri, make sure a board has at
+   least one card, then:
+   ```bash
+   curl -s http://127.0.0.1:7457/boards \
+     | python3 -m json.tool | grep -E '"id"|"title"' | head
+   ```
+   Note a board `id` (BID) and a card `id` (CID) from the output. Export them
+   so the snippets below are copy-paste:
+   ```bash
+   BID=<paste board id>
+   CID=<paste card id>
+   ```
+
+4. **Watch the reload log.** Open the Kanri window's devtools console
+   (right-click → Inspect Element, or the app's debug console). Each reload
+   prints: `[kanri-bridge] .kanri.dat changed externally — reloaded boards`.
+
+---
 
 ## Test 1 — live reload round-trip (spec check 3)
 
-1. Launch the patched Kanri build and open a board with at least one card.
-2. In a separate terminal, mutate a card via the daemon:
+1. With Kanri open on the board, run:
    ```bash
-   curl -sX PATCH http://127.0.0.1:7457/boards/<bid>/cards/<cid> \
+   curl -sX PATCH "http://127.0.0.1:7457/boards/$BID/cards/$CID" \
      -H 'Content-Type: application/json' -d '{"title":"Live edit"}'
    ```
-3. **Expected:** within ~500ms the card title updates in the Kanri UI with no
-   manual reload. The webview devtools console logs
-   `[kanri-bridge] .kanri.dat changed externally — reloaded boards`.
+2. **Expected:** within ~500ms the card title changes to "Live edit" in the
+   Kanri UI with no manual reload, and the console logs the reload line once.
+
+✅ PASS if the UI updates live. ❌ FAIL if you must reload manually.
 
 ## Test 2 — debounce (spec check 4)
 
-1. With Kanri open, fire 10 mutations in a tight burst:
+1. Fire 10 writes in a tight burst:
    ```bash
    for i in $(seq 1 10); do
-     curl -sX PATCH http://127.0.0.1:7457/boards/<bid>/cards/<cid> \
+     curl -sX PATCH "http://127.0.0.1:7457/boards/$BID/cards/$CID" \
        -H 'Content-Type: application/json' -d "{\"title\":\"v$i\"}" &
    done; wait
    ```
-2. **Expected:** the devtools console shows the reload log line **once**, not
-   ten times — the 150ms backend debounce collapses the burst into a single
-   `kanri-dat-changed` emit.
+2. **Expected:** the console shows the reload log line **once** (or twice at
+   most if the burst straddles the 150ms window) — not ten times. The card
+   ends showing the last write.
+
+✅ PASS if reloads ≪ 10 (effectively one). ❌ FAIL if it logs ~10 reloads.
 
 ## Test 3 — watcher cleanup on quit (spec check 5)
 
-1. With Kanri running, note the open descriptors on the store dir:
+1. With Kanri running:
    ```bash
-   PID=$(pgrep -f 'kanri$' | head -1)
-   lsof -p "$PID" | grep -c 'tech.trobonox.kanri'
+   PID=$(pgrep -f 'kanri.app/Contents/MacOS/kanri' | head -1)
+   echo "pid=$PID"
+   lsof -p "$PID" 2>/dev/null | grep -c 'tech.trobonox.kanri'   # baseline (>0)
    ```
 2. Quit Kanri (Cmd-Q).
-3. **Expected:** the process exits; `pgrep -f 'kanri$'` returns nothing and the
-   descriptors are gone. The watcher thread and its FSEvents handle are owned
-   by the process and released on exit — no zombie watcher.
+3. ```bash
+   sleep 2
+   pgrep -f 'kanri.app/Contents/MacOS/kanri' || echo "process gone"
+   ```
+
+✅ PASS if the process is gone after quit (the watcher thread + its FSEvents
+handle are owned by the process and released by the OS on exit — no zombie).
+❌ FAIL if a `kanri` process or its store fds linger.
 
 ## Test 4 — no regression (spec check 8)
 
-With the patched build, confirm core flows still work:
+With the patched build, exercise core flows by hand:
 
 - Drag a card between columns.
 - Edit a card (title, description, color).
-- Create a new board.
+- Create a new board, add a column, add a card.
 
-**Expected:** all succeed, no crashes, no console errors beyond the reload log.
+✅ PASS if all succeed with no crash and no console errors beyond the reload
+log line. ❌ FAIL on any crash or broken interaction.
+
+---
+
+## Reporting
+
+Record PASS/FAIL for tests 1–4. All four PASS → spec checks 3, 4, 5, 8 are
+green and the fork PR can be merged + the upstream PR opened.

--- a/tests/manual-watcher-test.md
+++ b/tests/manual-watcher-test.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# Manual test: `.kanri.dat` live-reload watcher
+
+The Tauri backend watches the data store and emits `kanri-dat-changed` when an
+external process (the [kanri-bridge](https://github.com/Iamcodio/IAC-023-kanri-bridge)
+daemon) writes `.kanri.dat`. The frontend reloads the board on that event, so
+changes appear live with no "Import board" click.
+
+A full Tauri UI test harness is out of scope; these are manual steps.
+
+## Prerequisites
+
+- A release build of this fork: `yarn install && yarn tauri build`
+  (or `yarn tauri dev` for a faster loop).
+- The kanri-bridge daemon built and runnable
+  (`cargo build --release` in the IAC-023-kanri-bridge repo).
+- Store path: `~/Library/Application Support/tech.trobonox.kanri/.kanri.dat`.
+
+> Point the daemon at the **real** store only deliberately. For these tests you
+> can either let it use the default path (real store, with Kanri open) or run
+> Kanri against a test store by launching it with that data dir.
+
+## Test 1 — live reload round-trip (spec check 3)
+
+1. Launch the patched Kanri build and open a board with at least one card.
+2. In a separate terminal, mutate a card via the daemon:
+   ```bash
+   curl -sX PATCH http://127.0.0.1:7457/boards/<bid>/cards/<cid> \
+     -H 'Content-Type: application/json' -d '{"title":"Live edit"}'
+   ```
+3. **Expected:** within ~500ms the card title updates in the Kanri UI with no
+   manual reload. The webview devtools console logs
+   `[kanri-bridge] .kanri.dat changed externally — reloaded boards`.
+
+## Test 2 — debounce (spec check 4)
+
+1. With Kanri open, fire 10 mutations in a tight burst:
+   ```bash
+   for i in $(seq 1 10); do
+     curl -sX PATCH http://127.0.0.1:7457/boards/<bid>/cards/<cid> \
+       -H 'Content-Type: application/json' -d "{\"title\":\"v$i\"}" &
+   done; wait
+   ```
+2. **Expected:** the devtools console shows the reload log line **once**, not
+   ten times — the 150ms backend debounce collapses the burst into a single
+   `kanri-dat-changed` emit.
+
+## Test 3 — watcher cleanup on quit (spec check 5)
+
+1. With Kanri running, note the open descriptors on the store dir:
+   ```bash
+   PID=$(pgrep -f 'kanri$' | head -1)
+   lsof -p "$PID" | grep -c 'tech.trobonox.kanri'
+   ```
+2. Quit Kanri (Cmd-Q).
+3. **Expected:** the process exits; `pgrep -f 'kanri$'` returns nothing and the
+   descriptors are gone. The watcher thread and its FSEvents handle are owned
+   by the process and released on exit — no zombie watcher.
+
+## Test 4 — no regression (spec check 8)
+
+With the patched build, confirm core flows still work:
+
+- Drag a card between columns.
+- Edit a card (title, description, color).
+- Create a new board.
+
+**Expected:** all succeed, no crashes, no console errors beyond the reload log.


### PR DESCRIPTION
## What

Add a filesystem watcher so Kanri reloads the active board when its data
store (`.kanri.dat`) is changed on disk by another process, instead of
requiring a manual re-import.

## Why

Kanri caches board state from `.kanri.dat` in memory, so any external writer
(a sync tool, a script, or in my case an HTTP daemon that owns the store) only
shows up after a manual "Import board". Watching the file closes that gap and
keeps the UI in sync with the source of truth.

## How

**Backend (`src-tauri/src/lib.rs`)**
- A `notify` watcher on the app-data **directory** (not the file path):
  external writers commonly replace the file via atomic `rename`, which swaps
  the inode and would invalidate a watch on the path itself. We watch the dir
  and filter for `.kanri.dat`.
- Events are debounced 150ms so a burst of writes collapses into a single
  `kanri-dat-changed` emit rather than a reload storm.
- The watcher runs on a background thread for the app's lifetime; its handle
  and OS resources are released on quit.

**Frontend (`plugins/kanriDatWatcher.client.ts`)**
- Listens for `kanri-dat-changed`, reloads the `LazyStore` cache from disk
  (`store.reload()`), then reloads boards via the existing
  `forceReloadBoards()` action — no new loader.

## Notes

- Adds `notify = "6"` to `src-tauri/Cargo.toml`.
- No behaviour change unless `.kanri.dat` is modified externally.
- Manual test recipe included at `tests/manual-watcher-test.md`
  (live round-trip, debounce, watcher cleanup on quit, regression).

Happy to adjust the event name, debounce window, or structure to fit project
conventions.