### PR TITLE
[codex] add productivity workflows and polish UI

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -23,6 +23,8 @@ body {
   overscroll-behavior: none;
   scroll-behavior: smooth;
   background-color: #111112;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 .smooth-dnd-container {
@@ -30,8 +32,36 @@ body {
 }
 
 body:has(> .disable-animations) * {
+  -webkit-animation: none !important;
+  -moz-animation: none !important;
+  -o-animation: none !important;
+  animation: none !important;
   -webkit-transition: none !important;
   -moz-transition: none !important;
   -o-transition: none !important;
   transition: none !important;
+}
+
+.smooth-dnd-draggable-wrapper {
+  transition:
+    transform 200ms cubic-bezier(0.4, 0, 0, 1),
+    opacity 120ms cubic-bezier(0.4, 1, 0.6, 1);
+}
+
+.smooth-dnd-ghost,
+.smooth-dnd-draggable-wrapper.animated {
+  transition:
+    transform 200ms cubic-bezier(0.4, 0, 0, 1),
+    opacity 120ms cubic-bezier(0.4, 1, 0.6, 1) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
 }

--- a/assets/css/scrollbars.css
+++ b/assets/css/scrollbars.css
@@ -29,8 +29,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 .custom-scrollbar::-webkit-scrollbar {
-  width: 12px;
-  height: 16px;
+  width: 10px;
+  height: 12px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-track {
@@ -41,7 +41,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: var(--elevation-2);
-  box-shadow: inset 0 0 10px 0 var(-elevation-1);
+  box-shadow: inset 0 0 10px 0 var(--elevation-1);
   border-left: solid 6px var(--elevation-1);
 }
 
@@ -51,7 +51,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 .custom-scrollbar-horizontal::-webkit-scrollbar {
   width: 6px;
-  height: 16px;
+  height: 12px;
 }
 
 .custom-scrollbar-horizontal::-webkit-scrollbar-track {

--- a/components/PinnedBar.vue
+++ b/components/PinnedBar.vue
@@ -20,9 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
   <nav
-    class="my-2 flex h-screen flex-col items-center justify-between overflow-y-auto overflow-x-hidden px-8 pb-6 pt-4"
+    class="my-2 flex h-screen flex-col items-center justify-between overflow-y-auto overflow-x-hidden px-5 pb-6 pt-4"
   >
-    <section id="tabitem-list" class="flex flex-col items-center gap-3">
+    <section id="tabitem-list" class="flex flex-col items-center gap-2.5">
       <PinnedItem
         v-for="board in pins"
         id="tabitem"

--- a/components/PinnedItem.vue
+++ b/components/PinnedItem.vue
@@ -24,13 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip v-if="isActive" :label="props.board.title">
         <template #trigger>
           <nuxt-link :to="'/kanban/' + props.board.id">
-            <div class="bg-elevation-3 transition-button rounded-md p-2">
+            <div class="bg-elevation-3 transition-button rounded-lg p-2 shadow-sm">
               <span
                 v-if="customChar"
-                class="flex size-7 items-center justify-center text-[20px] leading-none"
+                class="flex size-6 items-center justify-center text-lg leading-none"
                 >{{ customChar }}</span
               >
-              <component :is="selectedIcon" v-else class="size-7" />
+              <component :is="selectedIcon" v-else class="size-6" />
             </div>
           </nuxt-link>
         </template>
@@ -39,13 +39,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip v-else :label="props.board.title">
         <template #trigger>
           <nuxt-link :to="'/kanban/' + props.board.id">
-            <div class="bg-elevation-2-hover transition-button rounded-md p-2">
+            <div class="bg-elevation-2-hover transition-button rounded-lg p-2">
               <span
                 v-if="customChar"
-                class="flex size-7 items-center justify-center text-[20px] leading-none"
+                class="flex size-6 items-center justify-center text-lg leading-none"
                 >{{ customChar }}</span
               >
-              <component :is="selectedIcon" v-else class="size-7" />
+              <component :is="selectedIcon" v-else class="size-6" />
             </div>
           </nuxt-link>
         </template>

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
   <nav
-    class="border-elevation-1 bg-sidebar z-10 mr-8 flex h-screen flex-col items-center justify-between overflow-hidden border-r-2 px-8 pb-6 pt-5 shadow-md"
+    class="border-elevation-1 bg-sidebar z-10 mr-5 flex h-screen flex-col items-center justify-between overflow-hidden border-r px-5 pb-6 pt-5 shadow-sm"
   >
     <ModalNewBoard
       v-show="newBoardModalVisible"
@@ -33,10 +33,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       />
     </Teleport>
 
-    <section id="items-top" class="flex flex-col items-center gap-4">
+    <section id="items-top" class="flex flex-col items-center gap-3">
       <div id="logo" class="flex flex-row rounded-md">
         <IconKanri
-          class="text-accent-logo-icon size-9 pl-1"
+          class="text-accent-logo-icon sidebar-logo size-9 pl-1"
           @click="$router.push('/')"
         />
       </div>
@@ -44,21 +44,51 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip :label="$t('components.sidebar.home')">
         <template #trigger>
           <button
-            class="bg-elevation-2-hover transition-button rounded-md p-2"
+            :class="sidebarActionClass('/')"
             @click="$router.push('/')"
           >
-            <PhHouse class="size-7" />
+            <PhHouse class="size-6" />
           </button>
+        </template>
+      </Tooltip>
+
+      <Tooltip :label="$t('unifiedTodo.title')">
+        <template #trigger>
+          <nuxt-link to="/unified-todo">
+            <div :class="sidebarActionClass('/unified-todo')">
+              <PhListChecks class="size-6" />
+            </div>
+          </nuxt-link>
+        </template>
+      </Tooltip>
+
+      <Tooltip :label="$t('weeklyCalendar.title')">
+        <template #trigger>
+          <nuxt-link to="/weekly-calendar">
+            <div :class="sidebarActionClass('/weekly-calendar')">
+              <PhCalendarBlank class="size-6" />
+            </div>
+          </nuxt-link>
+        </template>
+      </Tooltip>
+
+      <Tooltip :label="$t('globalWorkflow.title')">
+        <template #trigger>
+          <nuxt-link to="/global-workflow">
+            <div :class="sidebarActionClass('/global-workflow')">
+              <PhKanban class="size-6" />
+            </div>
+          </nuxt-link>
         </template>
       </Tooltip>
 
       <Tooltip v-if="showSidebarBackArrow" :label="$t('components.sidebar.back')">
         <template #trigger>
           <button
-            class="bg-elevation-2-hover transition-button rounded-md p-2"
+            :class="sidebarActionClass()"
             @click="$router.go(-1)"
           >
-            <PhArrowBendUpLeft class="size-7" />
+            <PhArrowBendUpLeft class="size-6" />
           </button>
         </template>
       </Tooltip>
@@ -66,10 +96,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip v-if="showSidebarAddButton" :label="$t('components.sidebar.createNewBoard')">
         <template #trigger>
           <button
-            class="bg-elevation-2-hover transition-button rounded-md p-2"
+            :class="sidebarActionClass()"
             @click="newBoardModalVisible = true"
           >
-            <IconPhPlusCircleDuotone class="text-accent size-7" />
+            <IconPhPlusCircleDuotone class="text-accent size-6" />
           </button>
         </template>
       </Tooltip>
@@ -77,12 +107,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
     <PinnedBar />
 
-    <section id="icons-bottom" class="flex flex-col items-center gap-4">
+    <section id="icons-bottom" class="flex flex-col items-center gap-3">
       <Tooltip :label="$t('components.sidebar.importExport')">
         <template #trigger>
           <nuxt-link to="/import">
-            <div class="bg-elevation-2-hover transition-button rounded-md p-2">
-              <PhArrowsLeftRight class="size-7" />
+            <div :class="sidebarActionClass('/import')">
+              <PhArrowsLeftRight class="size-6" />
             </div>
           </nuxt-link>
         </template>
@@ -91,10 +121,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip :label="$t('components.sidebar.help')">
         <template #trigger>
           <button
-            class="bg-elevation-2-hover transition-button rounded-md p-2"
+            :class="sidebarActionClass()"
             @click="showSidebarHelpModal = true"
           >
-            <PhQuestion class="size-7" />
+            <PhQuestion class="size-6" />
           </button>
         </template>
       </Tooltip>
@@ -102,8 +132,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       <Tooltip :label="$t('components.sidebar.settings')">
         <template #trigger>
           <nuxt-link to="/settings">
-            <div class="bg-elevation-2-hover transition-button rounded-md p-2">
-              <PhGearSix class="size-7" />
+            <div :class="sidebarActionClass('/settings')">
+              <PhGearSix class="size-6" />
             </div>
           </nuxt-link>
         </template>
@@ -118,12 +148,23 @@ import {
   PhHouse,
   PhArrowsLeftRight,
   PhGearSix,
+  PhListChecks,
+  PhCalendarBlank,
+  PhKanban,
   PhQuestion,
 } from "@phosphor-icons/vue";
 
 const { showSidebarAddButton, showSidebarBackArrow, showSidebarHelpModal } = storeToRefs(useLayoutStore());
+const route = useRoute();
 
 const newBoardModalVisible = ref(false);
+
+const isActiveRoute = (path?: string) => Boolean(path && route.path === path);
+
+const sidebarActionClass = (path?: string) => [
+  "sidebar-action bg-elevation-2-hover transition-button rounded-lg p-2",
+  isActiveRoute(path) ? "sidebar-action-active" : "",
+];
 
 onMounted(async () => {
   document.addEventListener("keydown", keyDownListener);
@@ -143,12 +184,38 @@ const keyDownListener = (e: KeyboardEvent) => {
 
 <style scoped>
 .bg-sidebar {
-  background:
-    radial-gradient(
-      circle at top left,
-      var(--elevation-1) 10%,
-      transparent
-    ),
-    var(--bg-primary);
+  background-color: color-mix(in srgb, var(--bg-primary) 94%, var(--elevation-1));
+}
+
+.sidebar-logo,
+.sidebar-action {
+  transition:
+    background-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction),
+    color var(--motion-fast) var(--motion-ease-interaction),
+    opacity var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.sidebar-logo {
+  cursor: pointer;
+}
+
+.sidebar-logo:hover {
+  transform: translateY(-1px) scale(1.02);
+}
+
+.sidebar-action {
+  color: var(--text-dim-1);
+}
+
+.sidebar-action:hover {
+  color: var(--text);
+}
+
+.sidebar-action-active {
+  background-color: color-mix(in srgb, var(--accent) 16%, var(--elevation-2));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 34%, transparent);
+  color: var(--accent);
 }
 </style>

--- a/components/kanban/Card.vue
+++ b/components/kanban/Card.vue
@@ -30,20 +30,60 @@ limitations under the License.
             ? { 'background-color': cardBackgroundColor }
             : {},
         ]"
-        class="kanban-card border-elevation-3 flex min-h-[30px] w-full cursor-pointer flex-col items-start gap-1 rounded-[3px] border p-3"
+        class="kanban-card border-elevation-3 flex min-h-[30px] w-full cursor-pointer flex-col items-start gap-1 rounded-md border p-3 shadow-sm"
         @click.self="$emit('openEditCardModal', card)"
       >
         <div
           :class="{ 'pb-1': cardHasNoExtraProperties }"
-          class="flex w-full flex-row items-start justify-between"
+          class="flex w-full flex-row items-start justify-between gap-2"
         >
+          <CheckboxRoot
+            v-if="name !== '---'"
+            :checked="false"
+            :disabled="!canMoveRight"
+            :aria-label="canMoveRight
+              ? $t('unifiedTodo.markDone')
+              : $t('unifiedTodo.noNextColumn')"
+            :title="canMoveRight
+              ? $t('unifiedTodo.markDone')
+              : $t('unifiedTodo.noNextColumn')"
+            class="bg-elevation-4 bg-elevation-2-hover border-elevation-5 mt-0.5 flex size-5 shrink-0 appearance-none items-center justify-center rounded-md border outline-none disabled:cursor-not-allowed disabled:opacity-40"
+            @click.stop
+            @pointerdown.stop
+            @update:checked="markDone"
+          >
+            <CheckboxIndicator
+              class="flex size-full items-center justify-center rounded"
+            >
+              <PhCheck weight="bold" class="text-accent-lighter size-4" />
+            </CheckboxIndicator>
+          </CheckboxRoot>
+
+          <button
+            v-if="canScheduleWeekday && name !== '---'"
+            type="button"
+            :aria-label="scheduledWeekday
+              ? `Plan day: ${scheduledWeekday}`
+              : 'Choose plan day'"
+            :title="scheduledWeekday
+              ? `Plan day: ${scheduledWeekday}`
+              : 'Choose plan day'"
+            class="bg-elevation-4 bg-elevation-2-hover border-elevation-5 transition-button mt-0.5 flex h-5 min-w-8 shrink-0 items-center justify-center rounded-md border px-1 text-[10px] font-bold outline-none"
+            :class="scheduledWeekday ? '' : 'text-dim-2'"
+            :style="scheduledWeekdayStyle"
+            @click.stop="cycleScheduledWeekday"
+            @pointerdown.stop
+          >
+            {{ scheduledWeekday ?? "Gün" }}
+          </button>
+
           <p class="text-no-overflow mr-2 w-full min-w-[28px]">
             <ClickCounter
               v-if="!cardNameEditMode"
               @double-click="enableCardEditMode"
               @single-click="$emit('openEditCardModal', card)"
             >
-              <hr v-if="name === '---'" class="mt-0.5" />
+              <hr v-if="name === '---'" class="mt-0.5" >
               <p v-else ref="cardNameText">
                 {{ name }}
               </p>
@@ -120,7 +160,7 @@ limitations under the License.
             v-if="dueDate"
             class="flex flex-row items-center gap-1"
             :class="{
-              'text-buttons rounded-sm bg-accent px-1': isDueDateCompleted,
+              'text-buttons bg-accent rounded-sm px-1': isDueDateCompleted,
               'text-buttons rounded-sm bg-red-600 px-1': dueDateOverdue && !isDueDateCompleted,
             }"
           >
@@ -132,6 +172,58 @@ limitations under the License.
             <PhClock v-else :class="iconSizeClass" />
             <span :class="taskTextClass">{{ getFormattedDueDate }}</span>
           </div>
+
+          <button
+            v-if="sourceUrl && name !== '---'"
+            type="button"
+            class="text-dim-2 bg-elevation-3-hover flex max-w-full flex-row items-center gap-1 rounded-md px-1"
+            :title="sourceUrl"
+            @click.stop="openSourceUrl"
+            @pointerdown.stop
+          >
+            <PhLinkSimple :class="iconSizeClass" />
+            <span :class="taskTextClass" class="max-w-28 truncate">
+              {{ sourceTitle || sourceUrl }}
+            </span>
+          </button>
+        </div>
+
+        <div
+          v-if="visibleSubtasks.length > 0 && name !== '---'"
+          class="border-elevation-3/70 custom-scrollbar mt-1 flex max-h-28 w-full flex-col gap-1 overflow-y-auto border-t pt-2"
+        >
+          <button
+            v-for="(task, index) in visibleSubtasks"
+            :key="task.id ?? `${task.name}-${index}`"
+            type="button"
+            class="bg-elevation-3-hover flex w-full min-w-0 items-start gap-1.5 rounded-md px-1 py-0.5 text-left"
+            :title="task.name"
+            @click.stop="toggleSubtask(index)"
+            @pointerdown.stop
+          >
+            <CheckboxRoot
+              :checked="task.finished"
+              class="bg-elevation-4 bg-elevation-2-hover border-elevation-5 mt-0.5 flex size-4 shrink-0 appearance-none items-center justify-center rounded border outline-none"
+              @click.stop
+              @pointerdown.stop
+              @update:checked="(checked) => setSubtaskFinished(index, checked)"
+            >
+              <CheckboxIndicator
+                class="flex size-full items-center justify-center rounded"
+              >
+                <PhCheck weight="bold" class="text-accent-lighter size-3" />
+              </CheckboxIndicator>
+            </CheckboxRoot>
+            <span
+              class="min-w-0 flex-1 break-words text-xs leading-snug"
+              :class="[
+                task.finished ? cardTextColorDim : cardTextColor,
+                { 'line-through opacity-70': task.finished },
+              ]"
+            >
+              {{ task.name }}
+            </span>
+          </button>
         </div>
       </div>
     </ContextMenuTrigger>
@@ -165,17 +257,24 @@ limitations under the License.
 </template>
 
 <script setup lang="ts">
-import type { Card, Tag } from "@/types/kanban-types";
+import type { Card, ScheduledWeekday, Tag, Task } from "@/types/kanban-types";
 
 import { getContrast } from "~/utils/colorUtils";
+import {
+  getNextPlannedWeekday,
+  plannedWeekdayStyleFor,
+} from "@/utils/plannedWeekday";
 import { XMarkIcon } from "@heroicons/vue/24/solid";
 import {
+  PhCheck,
   PhCheckCircle,
   PhChecks,
   PhClock,
+  PhLinkSimple,
   PhListChecks,
   PhTextAlignLeft,
 } from "@phosphor-icons/vue";
+import { openSourceLink } from "@/utils/sourceLinks";
 
 import {
   ContextMenuContent,
@@ -187,6 +286,8 @@ import {
 
 const props = defineProps<{
   card: Card;
+  canMoveRight?: boolean;
+  canScheduleWeekday?: boolean;
   zoomLevel: number;
 }>();
 
@@ -203,6 +304,13 @@ const emit = defineEmits<{
   (e: "setCardName", cardId: string | undefined, name: string): void;
   (e: "updateCardTags", cardId: string | undefined, tags: Array<Tag>): void;
   (e: "duplicateCard", cardId: string | undefined): void;
+  (e: "markDone", cardId: string | undefined): void;
+  (e: "setCardTasks", cardId: string | undefined, tasks: Array<Task>): void;
+  (
+    e: "setScheduledWeekday",
+    cardId: string | undefined,
+    weekday: ScheduledWeekday
+  ): void;
 }>();
 
 const { locale } = useI18n();
@@ -221,6 +329,11 @@ const dueDate = ref(props.card.dueDate);
 const isDueDateRelative = ref(props.card.isDueDateCounterRelative);
 const isDueDateCompleted = ref(props.card.isDueDateCompleted ?? false);
 const cardTags = ref(props.card.tags);
+const scheduledWeekday = ref<ScheduledWeekday | null>(
+  props.card.scheduledWeekday ?? null
+);
+const sourceUrl = ref(props.card.sourceUrl ?? null);
+const sourceTitle = ref(props.card.sourceTitle ?? null);
 
 const cardNameEditMode = ref(false);
 const cardNameInput: Ref<HTMLTextAreaElement | null> = ref(null);
@@ -228,7 +341,7 @@ const cardNameText: Ref<HTMLParagraphElement | null> = ref(null);
 
 watch(
   props,
-  (_, newData) => {
+  (newData) => {
     name.value = newData.card.name;
     description.value = newData.card.description;
     tasks.value = newData.card.tasks;
@@ -236,6 +349,9 @@ watch(
     isDueDateRelative.value = newData.card.isDueDateCounterRelative;
     cardTags.value = newData.card.tags;
     isDueDateCompleted.value = newData.card.isDueDateCompleted ?? false;
+    scheduledWeekday.value = newData.card.scheduledWeekday ?? null;
+    sourceUrl.value = newData.card.sourceUrl ?? null;
+    sourceTitle.value = newData.card.sourceTitle ?? null;
   },
   { deep: true }
 );
@@ -249,6 +365,8 @@ const cardHasNoExtraProperties = computed(() => {
     (!tasks.value || tasks.value.length === 0) &&
     isDescriptionEmpty &&
     !dueDate.value &&
+    !scheduledWeekday.value &&
+    !sourceUrl.value &&
     (props.card.tags || []).length === 0 &&
     !props.card.name.startsWith("---")
   );
@@ -281,6 +399,8 @@ const allTasksCompleted = computed(() => {
 
   return false; //default return
 });
+
+const visibleSubtasks = computed(() => tasks.value ?? []);
 
 // New computed properties for scaling elements
 const zoomClass = computed(() => {
@@ -445,6 +565,49 @@ const dueDateOverdue = computed(() => {
   return false;
 });
 
+const markDone = (checked: boolean | "indeterminate") => {
+  if (checked === true && props.canMoveRight) {
+    emit("markDone", props.card.id);
+  }
+};
+
+const scheduledWeekdayStyle = computed(() =>
+  plannedWeekdayStyleFor(scheduledWeekday.value)
+);
+
+const cycleScheduledWeekday = () => {
+  if (!props.canScheduleWeekday) return;
+
+  const nextWeekday = getNextPlannedWeekday(scheduledWeekday.value);
+  scheduledWeekday.value = nextWeekday;
+  emit("setScheduledWeekday", props.card.id, nextWeekday);
+};
+
+const openSourceUrl = async () => {
+  await openSourceLink(sourceUrl.value);
+};
+
+const setSubtaskFinished = (
+  taskIndex: number,
+  checked: boolean | "indeterminate"
+) => {
+  if (checked === "indeterminate") return;
+
+  const nextTasks = (tasks.value ?? []).map((task, index) =>
+    index === taskIndex ? { ...task, finished: checked } : { ...task }
+  );
+
+  tasks.value = nextTasks;
+  emit("setCardTasks", props.card.id, nextTasks);
+};
+
+const toggleSubtask = (taskIndex: number) => {
+  const task = visibleSubtasks.value[taskIndex];
+  if (!task) return;
+
+  setSubtaskFinished(taskIndex, !task.finished);
+};
+
 const deleteCardWithConfirmation = (id: string | undefined) => {
   /*
     TODO: rewrite this, we are passing a ref through an emit which works for this usecase of DOM manipulation but might break reactivity
@@ -503,10 +666,27 @@ const updateCardName = () => {
 
 <style scoped>
 .kanban-card {
-  transition-duration: 550ms;
-  transition-timing-function: ease-out;
-  transition-property: opacity, text-decoration;
   opacity: 100%;
+  transform: translateZ(0);
+  transition:
+    opacity 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    text-decoration-color 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction),
+    border-color var(--motion-fast) var(--motion-ease-interaction);
+  will-change: transform;
+}
+
+.kanban-card:hover {
+  border-color: color-mix(in srgb, var(--elevation-3) 84%, var(--accent));
+  box-shadow:
+    0 8px 20px -20px rgba(0, 0, 0, 0.6),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  transform: translateY(-1px);
+}
+
+.kanban-card:active {
+  transform: translateY(0) scale(0.995);
 }
 
 .kanban-card.card-hidden {
@@ -517,6 +697,12 @@ const updateCardName = () => {
 .separator-card {
   margin-bottom: 0 !important;
   gap: 0.25rem !important;
+}
+
+.separator-card:hover,
+.separator-card:active {
+  box-shadow: none;
+  transform: none;
 }
 
 /* Zoom level classes for scaling */

--- a/components/kanban/Column.vue
+++ b/components/kanban/Column.vue
@@ -22,7 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
   <div
     ref="columnDOMElement"
     :class="[
-      'kanban-column bg-elevation-1 max-h-column flex flex-col rounded-lg p-2',
+      'kanban-column bg-elevation-1 border-elevation-2 max-h-column flex flex-col rounded-lg border p-2 shadow-sm',
       columnSizeClass,
       columnSpacingClass,
     ]"
@@ -36,7 +36,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     >
       <div v-if="!titleEditing" class="flex flex-row items-center gap-1.5">
         <h1
-          class="stop-text-overflow ml-1 font-bold text-lg"
+          class="stop-text-overflow ml-1 text-lg font-bold"
           @click="enableTitleEditing()"
         >
           {{ props.title }}
@@ -55,7 +55,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         v-focus
         :v-disable-spellcheck="settings.disableSpellcheck"
         :class="[
-          'bg-elevation-2 border-accent text-no-overflow -m-2 mr-2 w-full rounded-sm border-2 border-dotted px-2 outline-none font-bold text-lg',
+          'bg-elevation-2 border-accent text-no-overflow -m-2 mr-2 w-full rounded-sm border-2 border-dotted px-2 text-lg font-bold outline-none',
           inputSizeClass,
         ]"
         maxlength="1000"
@@ -65,32 +65,51 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           updateColumnTitle();
           emitter.emit('columnActionDone');
         "
-      />
+      >
       
       <Dropdown align="end">
         <template #trigger>
           <button
-          class="bg-elevation-1 bg-elevation-2-hover transition-button h-full rounded-md"
-          @click.prevent
+            class="bg-elevation-1 bg-elevation-2-hover transition-button h-full rounded-md px-1"
+            @click.prevent
           >
-          <EllipsisHorizontalIcon class="size-6" />
+            <EllipsisHorizontalIcon class="size-6" />
           </button>
         </template>
         <template #content>
+            <div
+              class="flex min-w-72 items-center justify-between gap-4 rounded-md px-4 py-2"
+              @click.stop
+            >
+              <span class="max-w-52 text-sm">
+                {{ $t('unifiedTodo.showColumn') }}
+              </span>
+              <SwitchRoot
+                :checked="includedInUnifiedTodo"
+                :aria-label="$t('unifiedTodo.showColumn')"
+                class="bg-elevation-2 bg-accent-checked relative flex h-[24px] w-[42px] shrink-0 cursor-pointer rounded-full shadow-sm focus-within:outline focus-within:outline-black"
+                @update:checked="setUnifiedTodoInclusion"
+              >
+                <SwitchThumb
+                  class="bg-button-text my-auto block size-[18px] translate-x-0.5 rounded-full shadow-sm transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]"
+                />
+              </SwitchRoot>
+            </div>
+            <div class="border-elevation-3 my-1 border-t" />
             <DropdownMenuItem
-              class="bg-elevation-2-hover w-full cursor-pointer rounded-md px-4 py-1.5 pr-6 text-left flex items-center gap-2"
+              class="bg-elevation-2-hover flex w-full cursor-pointer items-center gap-2 rounded-md px-4 py-1.5 pr-6 text-left"
               @click="enableCardAddMode(true)"
             >
                 {{$t('components.kanban.column.addCardTop')}}
             </DropdownMenuItem>
             <DropdownMenuItem
-              class="bg-elevation-2-hover w-full cursor-pointer rounded-md px-4 py-1.5 pr-6 text-left flex items-center gap-2"
+              class="bg-elevation-2-hover flex w-full cursor-pointer items-center gap-2 rounded-md px-4 py-1.5 pr-6 text-left"
               @click="$emit('removeAllColumnCards', id)"
             >
                  {{$t('components.kanban.card.deleteAllColumnCardsAction')}}               
             </DropdownMenuItem>
             <DropdownMenuItem
-              class="bg-elevation-2-hover w-full cursor-pointer rounded-md px-4 py-1.5 pr-6 text-left flex items-center gap-2"
+              class="bg-elevation-2-hover flex w-full cursor-pointer items-center gap-2 rounded-md px-4 py-1.5 pr-6 text-left"
               @click="$emit('removeColumn', id)"
             >
                 {{$t('components.kanban.column.deleteColumnAction')}}
@@ -106,6 +125,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         containerSpacingClass,
       ]"
       drag-class="cursor-grabbing"
+      drop-class="kanban-card-drop-target"
       drag-handle-selector=".kanbancard-drag"
       group-name="cards"
       orientation="vertical"
@@ -123,6 +143,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       >
         <KanbanCard
           :card="card"
+          :can-move-right="hasNextColumn"
+          :can-schedule-weekday="plannedWeekdayEnabled"
           :index="index"
           :zoom-level="zoomLevel"
           @disable-dragging="disableDragging"
@@ -133,6 +155,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           @set-card-name="setCardName"
           @update-card-tags="updateCardTags"
           @duplicate-card="duplicateCard"
+          @mark-done="markDone"
+          @set-card-tasks="setCardTasks"
+          @set-scheduled-weekday="setScheduledWeekday"
         />
       </Draggable>
     </Container>
@@ -148,7 +173,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         v-focus
         v-resizable
         :class="[
-          'bg-elevation-2 border-accent-focus border-2 border-transparent mb-2 overflow-hidden rounded-sm p-1 focus:border-dotted focus:outline-none',
+          'bg-elevation-2 border-accent-focus mb-2 overflow-hidden rounded-sm border-2 border-transparent p-1 focus:border-dotted focus:outline-none',
           textAreaSizeClass,
         ]"
         maxlength="5000"
@@ -195,7 +220,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     <div
       v-if="!cardAddMode"
       :class="[
-        'text-dim-1 bg-elevation-3-hover mt-2 flex cursor-pointer flex-row items-center gap-1 rounded-md py-1 font-medium',
+        'text-dim-1 bg-elevation-3-hover transition-button mt-2 flex cursor-pointer flex-row items-center gap-1 rounded-md p-1 font-medium',
         addCardButtonSpacingClass,
       ]"
       @click="enableCardAddMode()"
@@ -209,7 +234,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 </template>
 
 <script setup lang="ts">
-import type { Card, Tag } from "@/types/kanban-types";
+import type { Card, ScheduledWeekday, Tag, Task } from "@/types/kanban-types";
 import type { Ref } from "vue";
 
 import { applyDrag } from "@/utils/drag-n-drop";
@@ -217,12 +242,15 @@ import emitter from "@/utils/emitter";
 import { PlusIcon, EllipsisHorizontalIcon } from "@heroicons/vue/24/solid";
 //@ts-expect-error, sadly this library does not have ts typings
 import { Container, Draggable } from "vue3-smooth-dnd";
-import { useI18n } from "vue-i18n";
+import { isColumnIncludedInUnifiedTodo } from "@/utils/unifiedTodo";
+import { isPlannedColumnTitle } from "@/utils/plannedWeekday";
 
 const props = defineProps<{
   cardsList: Array<Card>;
   colIndex: number;
   id: string;
+  hasNextColumn?: boolean;
+  includeInUnifiedTodo?: boolean;
   title: string;
   zoomLevel: number;
   addToTopButtonShown?: boolean;
@@ -255,15 +283,27 @@ const emit = defineEmits<{
 
   // column actions
   (e: "updateColumnTitle", columnId: string, title: string): void;
+  (e: "setColumnUnifiedTodoInclusion", columnId: string, include: boolean): void;
   (e: "removeColumn", columnId: string): void;
   (e: "removeColumnNoConfirmation", columnId: string): void;
   (e: "setColumnEditIndex", columnIndex: number, eventType: string): void;
   (e: "setCardName", columnId: string, cardId: string | undefined, name: string): void;
+  (
+    e: "setCardTasks",
+    columnId: string,
+    cardId: string | undefined,
+    tasks: Array<Task>
+  ): void;
+  (
+    e: "setCardScheduledWeekday",
+    columnId: string,
+    cardId: string | undefined,
+    weekday: ScheduledWeekday
+  ): void;
   (e: "duplicateCard", columnId: string, cardId: string | undefined): void;
+  (e: "moveCardToNextColumn", columnId: string, cardId: string | undefined): void;
   (e: "reorderCards", columnId: string, newCardsOrder: Array<Card>): void;
 }>();
-
-const { t } = useI18n();
 
 const settings = useSettingsStore();
 
@@ -278,44 +318,54 @@ const cardAddModeAddToTopOfColumn = ref(false);
 const titleNew = ref(props.title);
 const titleEditing = ref(false);
 
+const includedInUnifiedTodo = computed(() =>
+  isColumnIncludedInUnifiedTodo({
+    cards: props.cardsList,
+    id: props.id,
+    includeInUnifiedTodo: props.includeInUnifiedTodo,
+    title: props.title,
+  })
+);
+
+const plannedWeekdayEnabled = computed(() => isPlannedColumnTitle(props.title));
+
 provide('columnId', props.id);
 
 const draggingEnabled = ref(true);
 
 const columnDOMElement = ref<HTMLDivElement | null>(null);
 
+const enableColumnTitleEditingHandler = (columnID: string) => {
+  if (columnID === props.id) {
+    enableTitleEditing();
+  }
+};
+
+const enableColumnCardAddModeHandler = (columnID: string) => {
+  if (columnID === props.id) {
+    enableCardAddMode();
+  } else {
+    cardAddMode.value = false;
+    newCardName.value = "";
+    draggingEnabled.value = true;
+  }
+};
+
+const resetColumnInputsHandler = () => {
+  cardAddMode.value = false;
+  newCardName.value = "";
+  titleEditing.value = false;
+};
+
 onMounted(() => {
   document.addEventListener("keydown", keyDownListener);
 
-  emitter.on("enableColumnTitleEditing", (columnID) => {
-    if (columnID === props.id) {
-      enableTitleEditing();
-    }
-  });
+  emitter.on("enableColumnTitleEditing", enableColumnTitleEditingHandler);
+  emitter.on("enableColumnCardAddMode", enableColumnCardAddModeHandler);
+  emitter.on("resetColumnInputs", resetColumnInputsHandler);
 
-  emitter.on("enableColumnCardAddMode", (columnID) => {
-    if (columnID === props.id) {
-      enableCardAddMode();
-    } else {
-      cardAddMode.value = false;
-      newCardName.value = "";
-      draggingEnabled.value = true;
-    }
-  });
-
-  emitter.on("resetColumnInputs", () => {
-    cardAddMode.value = false;
-    newCardName.value = "";
-    titleEditing.value = false;
-  });
-
-  emitter.on("columnDraggingOn", () => {
-    enableDragging();
-  });
-
-  emitter.on("columnDraggingOff", () => {
-    disableDragging();
-  });
+  emitter.on("columnDraggingOn", enableDragging);
+  emitter.on("columnDraggingOff", disableDragging);
 
   /**
    * Enforce adding IDs to all cards
@@ -397,21 +447,6 @@ const inputSizeClass = computed(() => {
       return "text-xl py-2";
     default:
       return "text-base py-1";
-  }
-});
-
-const iconSizeClass = computed(() => {
-  switch (props.zoomLevel) {
-    case -1:
-      return "size-4";
-    case 0:
-      return "size-4";
-    case 1:
-      return "size-5";
-    case 2:
-      return "size-6";
-    default:
-      return "size-4";
   }
 });
 
@@ -640,11 +675,11 @@ const filteredCards = computed(() => {
 onBeforeUnmount(() => {
   document.removeEventListener("keydown", keyDownListener);
 
-  emitter.off("enableColumnTitleEditing");
-  emitter.off("enableColumnCardAddMode");
-  emitter.off("resetColumnInputs");
-  emitter.off("columnDraggingOn");
-  emitter.off("columnDraggingOff");
+  emitter.off("enableColumnTitleEditing", enableColumnTitleEditingHandler);
+  emitter.off("enableColumnCardAddMode", enableColumnCardAddModeHandler);
+  emitter.off("resetColumnInputs", resetColumnInputsHandler);
+  emitter.off("columnDraggingOn", enableDragging);
+  emitter.off("columnDraggingOff", disableDragging);
 });
 
 const keyDownListener = (e: { key: string }) => {
@@ -733,6 +768,9 @@ const addCard = () => {
     dueDate: null,
     isDueDateCounterRelative: false,
     isDueDateCompleted: false,
+    scheduledWeekday: null,
+    sourceTitle: null,
+    sourceUrl: null,
     tags: [],
   };
 
@@ -749,6 +787,25 @@ const addCard = () => {
 
 const duplicateCard = (cardId: string | undefined) => {
   emit("duplicateCard", props.id, cardId);
+};
+
+const markDone = (cardId: string | undefined) => {
+  emit("moveCardToNextColumn", props.id, cardId);
+};
+
+const setCardTasks = (cardId: string | undefined, tasks: Array<Task>) => {
+  emit("setCardTasks", props.id, cardId, tasks);
+};
+
+const setScheduledWeekday = (
+  cardId: string | undefined,
+  weekday: ScheduledWeekday
+) => {
+  emit("setCardScheduledWeekday", props.id, cardId, weekday);
+};
+
+const setUnifiedTodoInclusion = (include: boolean) => {
+  emit("setColumnUnifiedTodoInclusion", props.id, include);
 };
 
 const scrollCardIntoView = () => {
@@ -793,6 +850,25 @@ const getGhostParent = () => {
 <style scoped>
 .max-h-column {
   max-height: calc(90vh - 100px);
+}
+
+.kanban-column {
+  background-color: var(--elevation-1);
+  transition:
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.kanban-column:hover {
+  border-color: var(--elevation-3);
+  box-shadow: 0 10px 24px -24px rgba(0, 0, 0, 0.6);
+}
+
+:deep(.kanban-card-drop-target) {
+  border-radius: 0.5rem;
+  outline: 1px dashed color-mix(in srgb, var(--accent) 75%, transparent);
+  outline-offset: -4px;
 }
 
 .stop-text-overflow {

--- a/composables/useBoard.ts
+++ b/composables/useBoard.ts
@@ -21,7 +21,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { computed, toValue } from "vue";
 import type { Ref } from "vue";
-import type { Board, Card, Column, Tag } from "@/types/kanban-types";
+import type {
+  Board,
+  Card,
+  Column,
+  ScheduledWeekday,
+  Tag,
+} from "@/types/kanban-types";
 import { useBoardsStore } from "@/stores/boards";
 
 export function useBoard(id: string | Ref<string>) {
@@ -84,6 +90,10 @@ export function useBoard(id: string | Ref<string>) {
     if (!board.value) return;
     store.setColumnTitle(board.value.id, columnId, title);
   }
+  function setColumnUnifiedTodoInclusion(columnId: string, include: boolean) {
+    if (!board.value) return;
+    store.setColumnUnifiedTodoInclusion(board.value.id, columnId, include);
+  }
 
   // Cards
   function createCard(columnId: string, card: Card, addToTop?: boolean) {
@@ -117,6 +127,11 @@ export function useBoard(id: string | Ref<string>) {
   function reorderCards(columnId: string, nextCards: Card[]) {
     if (!board.value) return;
     store.reorderCards(board.value.id, columnId, nextCards);
+  }
+
+  function moveCardToNextColumn(columnId: string, cardId: string | undefined) {
+    if (!board.value || !cardId) return;
+    store.moveCardToNextColumn(board.value.id, columnId, cardId);
   }
 
   const setCardName = (
@@ -201,6 +216,19 @@ export function useBoard(id: string | Ref<string>) {
     });
   };
 
+  const setCardScheduledWeekday = (
+    columnId: string,
+    cardId: string | undefined,
+    weekday: ScheduledWeekday
+  ) => {
+    if (!board.value) return;
+    if (!cardId) return;
+
+    mutateCard(columnId, cardId, (card) => {
+      card.scheduledWeekday = weekday;
+    });
+  };
+
   // (Global) Card Tags
   const addGlobalTag = (tag: Tag) => {
     if (!board.value) return;
@@ -243,6 +271,7 @@ export function useBoard(id: string | Ref<string>) {
     removeColumn,
     reorderColumns,
     setColumnTitle,
+    setColumnUnifiedTodoInclusion,
 
     // card actions
     createCard,
@@ -250,6 +279,7 @@ export function useBoard(id: string | Ref<string>) {
     deleteAllColumnCards,
     duplicateCard,
     mutateCard,
+    moveCardToNextColumn,
     reorderCards,
     setCardName,
     setCardDescription,
@@ -257,6 +287,7 @@ export function useBoard(id: string | Ref<string>) {
     setCardTasks,
     setCardDueDate,
     setCardTags,
+    setCardScheduledWeekday,
 
     // global tags
     addGlobalTag,

--- a/extensions/chrome-kanri-quick-add/README.md
+++ b/extensions/chrome-kanri-quick-add/README.md
@@ -1,0 +1,26 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Kanri Quick Add Chrome Extension
+
+This unpacked Chrome extension captures the active tab title and URL, lets you choose the target board inside the popup, then sends the task to a running Kanri app through the local quick-add bridge:
+
+```text
+http://127.0.0.1:47827/quick-add
+```
+
+```text
+http://127.0.0.1:47827/boards
+```
+
+Kanri exposes the available board names to the popup while the desktop app is running. The selected board receives the task in its `Idea` column. If that board has no `Idea` column, Kanri uses the leftmost column.
+
+## Local Install
+
+1. Run Kanri locally with `yarn tauri dev`, or install/run the desktop app.
+2. Open `chrome://extensions`.
+3. Enable Developer mode.
+4. Click Load unpacked.
+5. Select this folder: `extensions/chrome-kanri-quick-add`.
+
+On macOS, the local bridge works in dev mode while Kanri is running.

--- a/extensions/chrome-kanri-quick-add/manifest.json
+++ b/extensions/chrome-kanri-quick-add/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Kanri Quick Add",
+  "description": "Save the current Chrome tab to Kanri.",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Add task to Kanri"
+  },
+  "permissions": [
+    "activeTab",
+    "tabs"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1:47827/*"
+  ]
+}

--- a/extensions/chrome-kanri-quick-add/manifest.json.license
+++ b/extensions/chrome-kanri-quick-add/manifest.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/extensions/chrome-kanri-quick-add/popup.css
+++ b/extensions/chrome-kanri-quick-add/popup.css
@@ -1,0 +1,112 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-width: 340px;
+  background: #111827;
+  color: #f9fafb;
+}
+
+.popup {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+.eyebrow,
+.label,
+.status,
+.hint {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 12px;
+}
+
+.eyebrow {
+  color: #7dd3fc;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+}
+
+h2 {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 15px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.tab-card,
+.board-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  background: #1f2937;
+  padding: 12px;
+}
+
+.url {
+  overflow-wrap: anywhere;
+  margin: 0;
+  color: #d1d5db;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+select {
+  width: 100%;
+  border: 1px solid #4b5563;
+  border-radius: 7px;
+  background: #111827;
+  color: #f9fafb;
+  font: inherit;
+  padding: 9px 10px;
+}
+
+select:disabled {
+  color: #9ca3af;
+  opacity: 0.8;
+}
+
+button {
+  border: 0;
+  border-radius: 7px;
+  background: #0ea5e9;
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 10px 12px;
+}
+
+button:disabled {
+  background: #374151;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.status {
+  min-height: 16px;
+}

--- a/extensions/chrome-kanri-quick-add/popup.html
+++ b/extensions/chrome-kanri-quick-add/popup.html
@@ -1,0 +1,42 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Kanri Quick Add</title>
+    <link rel="stylesheet" href="popup.css">
+  </head>
+  <body>
+    <main class="popup">
+      <header>
+        <p class="eyebrow">Kanri</p>
+        <h1>Task Ekle</h1>
+      </header>
+
+      <section class="tab-card" aria-live="polite">
+        <p class="label">Mevcut sekme</p>
+        <h2 id="tab-title">Sekme okunuyor...</h2>
+        <p id="tab-url" class="url"></p>
+      </section>
+
+      <section class="board-card">
+        <label class="label" for="board-select">Kaydedilecek tablo</label>
+        <select id="board-select" disabled>
+          <option>Panolar okunuyor...</option>
+        </select>
+        <p id="target-column" class="hint"></p>
+      </section>
+
+      <button id="add-task" type="button" disabled>
+        Task Ekle
+      </button>
+
+      <p id="status" class="status" role="status"></p>
+    </main>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extensions/chrome-kanri-quick-add/popup.js
+++ b/extensions/chrome-kanri-quick-add/popup.js
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* global chrome */
+
+const QUICK_ADD_BRIDGE_URL = "http://127.0.0.1:47827/quick-add";
+const QUICK_ADD_BOARDS_URL = "http://127.0.0.1:47827/boards";
+
+const titleElement = document.querySelector("#tab-title");
+const urlElement = document.querySelector("#tab-url");
+const boardSelect = document.querySelector("#board-select");
+const targetColumnElement = document.querySelector("#target-column");
+const addButton = document.querySelector("#add-task");
+const statusElement = document.querySelector("#status");
+
+let currentTab = null;
+let boards = [];
+let bridgeAvailable = false;
+
+const isSupportedUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const setStatus = (message) => {
+  statusElement.textContent = message;
+};
+
+const selectedBoard = () =>
+  boards.find((board) => board.id === boardSelect.value) ?? null;
+
+const updateActionState = () => {
+  const supported = isSupportedUrl(currentTab?.url || "");
+  const board = selectedBoard();
+
+  addButton.disabled = !supported || !bridgeAvailable || !board;
+  targetColumnElement.textContent = board
+    ? `${board.targetColumn || "Idea"} kolonuna kaydedilecek.`
+    : "";
+
+  if (!supported) {
+    setStatus("Yalnızca http/https sayfaları task olarak eklenebilir.");
+    return;
+  }
+
+  if (!bridgeAvailable) {
+    setStatus("Kanri uygulamasını açıp tekrar deneyin.");
+    return;
+  }
+
+  if (boards.length === 0) {
+    setStatus("Kanri'de kayıtlı tablo bulunamadı.");
+    return;
+  }
+
+  setStatus("Tabloyu seçip task'i kaydedebilirsin.");
+};
+
+const renderTab = (tab) => {
+  currentTab = tab;
+
+  const title = tab?.title?.trim() || "Başlıksız sayfa";
+  const url = tab?.url || "";
+
+  titleElement.textContent = title;
+  urlElement.textContent = url;
+  updateActionState();
+};
+
+const renderBoards = () => {
+  boardSelect.textContent = "";
+  boardSelect.disabled = !bridgeAvailable || boards.length === 0;
+
+  if (!bridgeAvailable) {
+    const option = document.createElement("option");
+    option.textContent = "Kanri bağlantısı yok";
+    boardSelect.append(option);
+    updateActionState();
+    return;
+  }
+
+  if (boards.length === 0) {
+    const option = document.createElement("option");
+    option.textContent = "Tablo bulunamadı";
+    boardSelect.append(option);
+    updateActionState();
+    return;
+  }
+
+  for (const board of boards) {
+    const option = document.createElement("option");
+    option.value = board.id;
+    option.textContent = board.title || "Başlıksız tablo";
+    boardSelect.append(option);
+  }
+
+  updateActionState();
+};
+
+const fetchBoards = async () => {
+  try {
+    const response = await fetch(QUICK_ADD_BOARDS_URL);
+    if (!response.ok) {
+      throw new Error(`Kanri bridge rejected the request: ${response.status}`);
+    }
+
+    const data = await response.json();
+    boards = Array.isArray(data.boards) ? data.boards : [];
+    bridgeAvailable = true;
+  } catch {
+    boards = [];
+    bridgeAvailable = false;
+  }
+
+  renderBoards();
+};
+
+const sendToBridge = async (tab, boardId) => {
+  const response = await fetch(QUICK_ADD_BRIDGE_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      boardId,
+      title: tab.title || "",
+      url: tab.url || "",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Kanri bridge rejected the request: ${response.status}`);
+  }
+};
+
+const openInKanri = async () => {
+  if (!currentTab || !isSupportedUrl(currentTab.url)) return;
+  const board = selectedBoard();
+  if (!board) return;
+
+  setStatus("Kanri'ye gönderiliyor...");
+  addButton.disabled = true;
+
+  try {
+    await sendToBridge(currentTab, board.id);
+    setStatus("Kanri'ye gönderildi.");
+    window.close();
+    return;
+  } catch {
+    setStatus("Kaydedilemedi. Kanri açık mı kontrol edip tekrar dene.");
+    addButton.disabled = false;
+  }
+};
+
+
+chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+  renderTab(tab);
+});
+
+void fetchBoards();
+boardSelect.addEventListener("change", updateActionState);
+addButton.addEventListener("click", openInKanri);

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -242,5 +242,27 @@
       "name": "Board-Name",
       "placeholder": "Gib den neuen Namen deines Boards ein"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -17,6 +17,8 @@
     "index": {
       "welcome": "Welcome back to Kanri!",
       "welcomeSubtext": "Your boards are ready and waiting for you.",
+      "searchBoardsPlaceholder": "Search boards...",
+      "noBoardsMatch": "No boards match your search.",
       "editSortWarning": "Warning: there is at least one board which does not have a valid last edited date. This is probably a remainder from a board created in an old version of Kanri. Please edit all boards at least once to mitigate this behaviour.",
       "sortAlphabetically": "Sort alphabetically",
       "sortByCreationDate": "Sort by creation date",
@@ -251,5 +253,51 @@
       "name": "Board Name",
       "placeholder": "Enter a new name for the board"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from the board columns included in Unified To-Do, kept connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "weeklyCalendar": {
+    "eyebrow": "Planned week",
+    "title": "Weekly Calendar",
+    "plannedTasks": "planned tasks",
+    "dropHere": "Drop planned tasks here",
+    "unscheduledTitle": "Unscheduled Planned tasks",
+    "unscheduledHint": "Drag cards from here onto a weekday to assign them.",
+    "noUnscheduledTasks": "Every Planned task has a weekday."
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
+  },
+  "quickAdd": {
+    "eyebrow": "Browser capture",
+    "title": "Add Current Tab",
+    "currentTab": "Current tab",
+    "missingUrl": "No URL received.",
+    "unsupportedUrl": "Only http and https URLs can be saved from the extension.",
+    "chooseBoard": "Choose board",
+    "noBoards": "No boards found. Create a board first.",
+    "targetColumn": "Will save to {column}",
+    "newIdeaColumn": "Will create Idea column",
+    "saveFailed": "Could not save this task.",
+    "saved": "Saved to {board}.",
+    "openBoard": "Open board",
+    "untitledPage": "Untitled page"
   }
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -242,5 +242,27 @@
       "name": "Nombre del Tablero",
       "placeholder": "Introduzca un nuevo nombre para el tablero"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -242,5 +242,27 @@
       "name": "Nom du tableau",
       "placeholder": "Entrez un nouveau nom pour le tableau"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -251,5 +251,27 @@
       "name": "ボード名",
       "placeholder": "ボードの新しい名前を入力"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/pt_br.json
+++ b/i18n/locales/pt_br.json
@@ -242,5 +242,27 @@
       "name": "Nome do quadro",
       "placeholder": "Digite um nome para o quadro"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -242,5 +242,27 @@
       "name": "Название доски",
       "placeholder": "Введите новое название для доски"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -245,5 +245,27 @@
       "name": "ชื่อบอร์ด",
       "placeholder": "ป้อนชื่อบอร์ดใหม่"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/tr.json
+++ b/i18n/locales/tr.json
@@ -16,6 +16,8 @@
     "index": {
       "welcome": "Kanri'ye tekrar hoş geldiniz!",
       "welcomeSubtext": "Panolarınız hazır ve sizi bekliyor.",
+      "searchBoardsPlaceholder": "Panolarda ara...",
+      "noBoardsMatch": "Aramanızla eşleşen pano yok.",
       "editSortWarning": "Uyarı: geçerli bir son düzenleme tarihi olmayan en az bir pano var. Bu muhtemelen Kanri'nin eski bir sürümünde oluşturulan bir panodan kalmadır. Bu davranışı düzeltmek için lütfen tüm panoları en az bir kez düzenleyin.",
       "sortAlphabetically": "Alfabetik olarak sırala",
       "sortByCreationDate": "Oluşturma tarihine göre sırala",
@@ -242,5 +244,51 @@
       "name": "Pano Adı",
       "placeholder": "Pano için yeni bir isim girin"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Genel görev görünümü",
+    "title": "Unified To-Do",
+    "description": "Dahil edilen pano sütunlarındaki tüm görevler; her biri özgün kartına bağlı kalır.",
+    "boardFilter": "Pano filtresi",
+    "allBoards": "Tüm Panolar",
+    "noTasks": "Şu anda yapılacak görev yok.",
+    "noFilterMatches": "Bu pano filtresiyle eşleşen görev yok.",
+    "lastColumn": "Sonraki sütun yok",
+    "showColumn": "Bu sütundaki görevleri Unified To-Do'da göster",
+    "markDone": "Tamamlandı olarak işaretle ve sağdaki sütuna taşı",
+    "noNextColumn": "Bu kart zaten son sütunda"
+  },
+  "weeklyCalendar": {
+    "eyebrow": "Hafta planı",
+    "title": "Haftalık Takvim",
+    "plannedTasks": "planlı görev",
+    "dropHere": "Planlı görevleri buraya sürükle",
+    "unscheduledTitle": "Günü seçilmemiş Planned görevleri",
+    "unscheduledHint": "Kartları buradan bir güne sürükleyerek haftaya dağıt.",
+    "noUnscheduledTasks": "Tüm Planned görevlerine gün atanmış."
+  },
+  "globalWorkflow": {
+    "eyebrow": "Genel tablo akışı",
+    "title": "Genel Akış",
+    "boards": "tablo",
+    "tasks": "task",
+    "dropHere": "Taskleri buraya sürükle",
+    "chooseDay": "Gün",
+    "cycleWeekday": "Plan gününü değiştir"
+  },
+  "quickAdd": {
+    "eyebrow": "Tarayıcı yakalama",
+    "title": "Sekmeyi Task Olarak Ekle",
+    "currentTab": "Mevcut sekme",
+    "missingUrl": "URL alınamadı.",
+    "unsupportedUrl": "Eklentiden yalnızca http ve https URL'leri kaydedilebilir.",
+    "chooseBoard": "Pano seç",
+    "noBoards": "Pano bulunamadı. Önce bir pano oluştur.",
+    "targetColumn": "{column} sütununa kaydedilecek",
+    "newIdeaColumn": "Idea sütunu oluşturulacak",
+    "saveFailed": "Bu task kaydedilemedi.",
+    "saved": "{board} panosuna kaydedildi.",
+    "openBoard": "Panoyu aç",
+    "untitledPage": "Başlıksız sayfa"
   }
 }

--- a/i18n/locales/uk.json
+++ b/i18n/locales/uk.json
@@ -242,5 +242,27 @@
       "name": "Назва дошки",
       "placeholder": "Введіть нову назву для дошки"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/i18n/locales/zh_cn.json
+++ b/i18n/locales/zh_cn.json
@@ -242,5 +242,27 @@
       "name": "看板名称",
       "placeholder": "输入新的看板名称"
     }
+  },
+  "unifiedTodo": {
+    "eyebrow": "Global task view",
+    "title": "Unified To-Do",
+    "description": "All tasks from included board columns, connected to their original cards.",
+    "boardFilter": "Board filter",
+    "allBoards": "All Boards",
+    "noTasks": "No tasks to do right now.",
+    "noFilterMatches": "No tasks match this board filter.",
+    "lastColumn": "No next column",
+    "showColumn": "Show tasks from this column in Unified To-Do",
+    "markDone": "Mark done and move to the next column",
+    "noNextColumn": "This card is already in the last column"
+  },
+  "globalWorkflow": {
+    "eyebrow": "Global board flow",
+    "title": "Global Workflow",
+    "boards": "boards",
+    "tasks": "tasks",
+    "dropHere": "Drop tasks here",
+    "chooseDay": "Day",
+    "cycleWeekday": "Change planned weekday"
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -137,6 +137,10 @@ const cssVars = computed(() => {
 
 <style>
 .disable-animations * {
+  -webkit-animation: none !important;
+  -moz-animation: none !important;
+  -o-animation: none !important;
+  animation: none !important;
   -webkit-transition: none !important;
   -moz-transition: none !important;
   -o-transition: none !important;
@@ -144,10 +148,15 @@ const cssVars = computed(() => {
 }
 
 .default-layout {
+  --motion-fast: 120ms;
+  --motion-standard: 200ms;
+  --motion-ease-interaction: cubic-bezier(0.4, 1, 0.6, 1);
+  --motion-ease-transition: cubic-bezier(0, 0.4, 0, 1);
   background-color: var(--bg-primary);
   color: var(--text);
-  transition: color 0.5s cubic-bezier(0.17, 0.67, 0.83, 0.67);
-  transition: background-color 0.5s cubic-bezier(0.17, 0.67, 0.83, 0.67);
+  transition:
+    background-color var(--motion-standard) var(--motion-ease-transition),
+    color var(--motion-standard) var(--motion-ease-transition);
   overscroll-behavior: none;
 }
 
@@ -293,37 +302,51 @@ const cssVars = computed(() => {
 
 .transition-button {
   transition-property:
-    color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 300ms;
+    color, background-color, border-color, box-shadow, opacity, transform, text-decoration-color, fill, stroke;
+  transition-timing-function: var(--motion-ease-interaction);
+  transition-duration: var(--motion-fast);
+}
+
+.transition-button:active {
+  transform: translateY(0) scale(0.98);
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 78%, white);
+  outline-offset: 2px;
 }
 
 .page-enter-active,
 .page-leave-active {
   transition:
-    opacity 220ms cubic-bezier(0.4, 0, 0.2, 0.8),
-    transform 220ms cubic-bezier(0.4, 0, 0.2, 0.8);
+    opacity var(--motion-standard) var(--motion-ease-transition),
+    transform var(--motion-standard) var(--motion-ease-transition);
   will-change: opacity, transform;
   overflow: hidden;
 }
 
 .page-enter-from {
   opacity: 0;
-  transform: translateY(30px) scale(0.98);
+  transform: translateY(4px);
 }
 
 .page-enter-to {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: translateY(0);
 }
 
 .page-leave-from {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: translateY(0);
 }
 
 .page-leave-to {
   opacity: 0;
-  transform: translateY(-10px) scale(0.99);
+  transform: translateY(-2px);
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@popperjs/core": "^2.11.8",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "2.6.0",
     "@tauri-apps/plugin-fs": "2.4.5",
     "@tauri-apps/plugin-log": "2.8.0",

--- a/pages/global-workflow.vue
+++ b/pages/global-workflow.vue
@@ -1,0 +1,297 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<template>
+  <div class="flex h-screen min-w-0 flex-col overflow-hidden px-6 py-5">
+    <header class="mb-4 flex shrink-0 items-center justify-between gap-4">
+      <div>
+        <div class="text-dim-2 mb-1 flex items-center gap-1.5">
+          <PhKanban class="size-4" />
+          <span class="text-xs font-medium">
+            {{ $t("globalWorkflow.eyebrow") }}
+          </span>
+        </div>
+        <h1 class="text-2xl font-semibold">
+          {{ $t("globalWorkflow.title") }}
+        </h1>
+      </div>
+
+      <div class="text-dim-2 flex shrink-0 items-center gap-2 text-xs tabular-nums">
+        <span>
+          {{ eligibleBoardCount }} {{ $t("globalWorkflow.boards") }}
+        </span>
+        <span class="opacity-50">·</span>
+        <span>
+          {{ totalItemCount }} {{ $t("globalWorkflow.tasks") }}
+        </span>
+      </div>
+    </header>
+
+    <main class="grid min-h-0 flex-1 grid-cols-6 gap-2">
+      <article
+        v-for="column in columns"
+        :key="column"
+        class="workflow-column bg-elevation-1 border-elevation-2 flex min-w-0 flex-col rounded-lg border p-2"
+      >
+        <header class="mb-2 flex items-center justify-between gap-2">
+          <h2 class="truncate text-sm font-bold">
+            {{ column }}
+          </h2>
+          <span class="bg-elevation-2 text-dim-2 rounded-full px-2 py-0.5 text-xs">
+            {{ workflow[column].length }}
+          </span>
+        </header>
+
+        <Container
+          class="custom-scrollbar min-h-0 flex-1 overflow-y-auto"
+          drag-class="cursor-grabbing"
+          drop-class="global-workflow-drop-target"
+          group-name="global-workflow-cards"
+          orientation="vertical"
+          :get-child-payload="(index: number) => workflow[column][index]"
+          @drop="dropOnColumn($event, column)"
+        >
+          <div
+            v-if="workflow[column].length === 0"
+            class="text-dim-2 border-elevation-3 flex min-h-24 items-center justify-center rounded-md border border-dashed px-2 text-center text-xs"
+          >
+            {{ $t("globalWorkflow.dropHere") }}
+          </div>
+
+          <Draggable
+            v-for="item in workflow[column]"
+            :key="itemKey(item)"
+            class="mb-2"
+          >
+            <article
+              class="global-workflow-card bg-elevation-2 border-elevation-3 bg-elevation-3-hover cursor-grab rounded-md border p-2 shadow-sm active:cursor-grabbing"
+            >
+              <div class="flex items-start justify-between gap-2">
+                <p class="line-clamp-3 min-w-0 break-words text-sm font-semibold">
+                  {{ item.card.name }}
+                </p>
+                <button
+                  v-if="item.workflowColumn === 'Planned'"
+                  type="button"
+                  class="shrink-0 rounded-md border px-1.5 py-0.5 text-[11px] font-bold"
+                  :style="plannedWeekdayStyleFor(item.card.scheduledWeekday)"
+                  :title="$t('globalWorkflow.cycleWeekday')"
+                  @click.stop="cyclePlannedWeekday(item)"
+                  @pointerdown.stop
+                >
+                  {{ item.card.scheduledWeekday || $t("globalWorkflow.chooseDay") }}
+                </button>
+              </div>
+
+              <p class="text-dim-2 mt-1 truncate text-[11px]">
+                {{ item.boardTitle }}
+              </p>
+
+              <div
+                v-if="item.card.tags?.length"
+                class="mt-2 flex flex-wrap gap-1"
+              >
+                <span
+                  v-for="tag in item.card.tags"
+                  :key="`${itemKey(item)}-${tag.id ?? tag.text}`"
+                  class="max-w-full truncate rounded-sm px-1.5 py-0.5 text-[10px] font-semibold"
+                  :style="tag.style"
+                >
+                  {{ tag.text }}
+                </span>
+              </div>
+
+              <div
+                v-if="item.card.tasks?.length"
+                class="mt-2 flex flex-col gap-1"
+              >
+                <label
+                  v-for="(task, taskIndex) in item.card.tasks.slice(0, 3)"
+                  :key="task.id ?? `${itemKey(item)}-task-${taskIndex}`"
+                  class="text-dim-2 flex min-w-0 items-center gap-1 text-[11px]"
+                  @pointerdown.stop
+                >
+                  <input
+                    class="size-3 accent-current"
+                    type="checkbox"
+                    :checked="task.finished"
+                    @change.stop="setSubtaskFinishedFromEvent(item, taskIndex, $event)"
+                  >
+                  <span
+                    class="truncate"
+                    :class="{ 'line-through opacity-70': task.finished }"
+                  >
+                    {{ task.name }}
+                  </span>
+                </label>
+              </div>
+
+              <button
+                v-if="item.card.sourceUrl"
+                type="button"
+                class="text-dim-2 bg-elevation-3-hover mt-2 flex max-w-full items-center gap-1 rounded-sm px-1 text-[11px]"
+                :title="item.card.sourceUrl"
+                @click.stop="openSourceUrl(item.card.sourceUrl)"
+                @pointerdown.stop
+              >
+                <PhLinkSimple class="size-3" />
+                <span class="truncate">
+                  {{ item.card.sourceTitle || item.card.sourceUrl }}
+                </span>
+              </button>
+            </article>
+          </Draggable>
+        </Container>
+      </article>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {
+  GlobalWorkflowColumn,
+  GlobalWorkflowItem,
+} from "@/utils/globalWorkflow";
+import { PhKanban, PhLinkSimple } from "@phosphor-icons/vue";
+import {
+  GLOBAL_WORKFLOW_COLUMNS,
+  aggregateGlobalWorkflowItems,
+  findGlobalWorkflowColumnId,
+  isGlobalWorkflowBoard,
+} from "@/utils/globalWorkflow";
+import {
+  getNextPlannedWeekday,
+  plannedWeekdayStyleFor,
+} from "@/utils/plannedWeekday";
+import { openSourceLink } from "@/utils/sourceLinks";
+//@ts-expect-error, sadly this library does not have ts typings
+import { Container, Draggable } from "vue3-smooth-dnd";
+
+const boardsStore = useBoardsStore();
+const layoutStore = useLayoutStore();
+const { boards } = storeToRefs(boardsStore);
+
+const columns = GLOBAL_WORKFLOW_COLUMNS;
+const workflow = computed(() => aggregateGlobalWorkflowItems(boards.value));
+const eligibleBoardCount = computed(
+  () => boards.value.filter(isGlobalWorkflowBoard).length
+);
+const totalItemCount = computed(() =>
+  columns.reduce((total, column) => total + workflow.value[column].length, 0)
+);
+
+onMounted(async () => {
+  layoutStore.onHomePageLeave();
+  await boardsStore.init();
+});
+
+const itemKey = (item: GlobalWorkflowItem) =>
+  `${item.boardId}-${item.columnId}-${item.card.id ?? item.cardOrder}`;
+
+const openSourceUrl = async (sourceUrl: string) => {
+  await openSourceLink(sourceUrl);
+};
+
+const moveItemToColumn = (
+  item: GlobalWorkflowItem,
+  targetColumn: GlobalWorkflowColumn
+) => {
+  if (!item.card.id || item.workflowColumn === targetColumn) return;
+
+  const board = boardsStore.boardById(item.boardId);
+  if (!board) return;
+
+  const targetColumnId = findGlobalWorkflowColumnId(board, targetColumn);
+  if (!targetColumnId) return;
+
+  boardsStore.moveCard(
+    item.boardId,
+    item.boardId,
+    item.columnId,
+    targetColumnId,
+    item.card.id
+  );
+};
+
+const cyclePlannedWeekday = (item: GlobalWorkflowItem) => {
+  if (!item.card.id || item.workflowColumn !== "Planned") return;
+
+  boardsStore.mutateCard(item.boardId, item.columnId, item.card.id, (card) => {
+    card.scheduledWeekday = getNextPlannedWeekday(card.scheduledWeekday);
+  });
+};
+
+const setSubtaskFinished = (
+  item: GlobalWorkflowItem,
+  taskIndex: number,
+  finished: boolean
+) => {
+  if (!item.card.id) return;
+
+  boardsStore.mutateCard(item.boardId, item.columnId, item.card.id, (card) => {
+    card.tasks = card.tasks?.map((task, index) =>
+      index === taskIndex ? { ...task, finished } : task
+    );
+  });
+};
+
+const setSubtaskFinishedFromEvent = (
+  item: GlobalWorkflowItem,
+  taskIndex: number,
+  event: Event
+) => {
+  setSubtaskFinished(
+    item,
+    taskIndex,
+    Boolean((event.target as HTMLInputElement | null)?.checked)
+  );
+};
+
+type GlobalWorkflowDropResult = {
+  addedIndex: number | null;
+  payload?: GlobalWorkflowItem;
+  removedIndex: number | null;
+};
+
+const dropOnColumn = (
+  dropResult: GlobalWorkflowDropResult,
+  targetColumn: GlobalWorkflowColumn
+) => {
+  if (dropResult.addedIndex === null || !dropResult.payload) return;
+
+  moveItemToColumn(dropResult.payload, targetColumn);
+};
+</script>
+
+<style scoped>
+.global-workflow-card {
+  transform: translateZ(0);
+  transition:
+    opacity var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction),
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.workflow-column {
+  background-color: var(--elevation-1);
+  transition:
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.workflow-column:hover {
+  border-color: var(--elevation-3);
+}
+
+.global-workflow-card:hover {
+  border-color: color-mix(in srgb, var(--elevation-3) 84%, var(--accent));
+  box-shadow: 0 8px 20px -20px rgba(0, 0, 0, 0.6);
+  transform: translateY(-1px);
+}
+
+:deep(.global-workflow-drop-target) {
+  border-color: var(--accent);
+}
+</style>

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -19,28 +19,28 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
-  <main id="settings" class="overflow-auto pl-8 pt-6">
-    <h1 class="text-4xl font-bold">
+  <main id="settings" class="h-screen overflow-auto px-6 py-5">
+    <h1 class="text-2xl font-semibold">
       {{ $t("pages.import.importExportHeading") }}
     </h1>
     <span class="text-dim-3">{{ $t("pages.import.importExportSubtext") }}</span>
 
-    <TabsRoot class="mt-4 flex w-1/2 flex-col" default-value="tab1">
+    <TabsRoot class="mt-4 flex w-full max-w-3xl flex-col" default-value="tab1">
       <TabsList
-        class="bg-elevation-1 relative flex shrink-0 rounded-md"
+        class="bg-elevation-1 border-elevation-2 relative flex shrink-0 rounded-lg border p-1"
         aria-label="Manage your account"
       >
         <TabsIndicator
-          class="bg-elevation-2 absolute bottom-0 left-0 h-full w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-md transition-[width,transform] duration-300"
+          class="bg-elevation-2 absolute inset-y-1 left-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-md transition-[width,transform] duration-200"
         />
         <TabsTrigger
-          class="tab-active-text z-10 flex h-[45px] flex-1 cursor-pointer select-none items-center justify-center rounded-md px-2 text-[16px] leading-none outline-none transition-colors duration-300"
+          class="tab-active-text z-10 flex h-9 flex-1 cursor-pointer select-none items-center justify-center rounded-md px-2 text-sm leading-none outline-none transition-colors duration-150"
           value="tab1"
         >
           {{ $t("general.importAction") }}
         </TabsTrigger>
         <TabsTrigger
-          class="tab-active-text z-10 flex h-[45px] flex-1 cursor-pointer select-none items-center justify-center rounded-md px-2 text-[16px] leading-none outline-none transition-colors duration-300"
+          class="tab-active-text z-10 flex h-9 flex-1 cursor-pointer select-none items-center justify-center rounded-md px-2 text-sm leading-none outline-none transition-colors duration-150"
           value="tab2"
         >
           {{ $t("general.exportAction") }}
@@ -48,7 +48,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       </TabsList>
       <TabsContent class="grow rounded-b-md pt-8 outline-none" value="tab1">
         <div>
-          <h2 class="mb-0.5 text-2xl font-bold">
+          <h2 class="mb-0.5 text-lg font-semibold">
             {{ $t("pages.import.importTabHeading") }}
           </h2>
           <p class="text-dim-2 mb-2">
@@ -104,7 +104,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       </TabsContent>
       <TabsContent class="grow rounded-b-md pt-8 outline-none" value="tab2">
         <div class="flex flex-col gap-4">
-          <h2 class="mb-2 text-2xl font-bold">
+          <h2 class="mb-2 text-lg font-semibold">
             {{ $t("pages.import.exportTabHeading") }}
           </h2>
           <div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
-  <div class="overflow-auto pl-8 pt-5">
+  <div class="overflow-auto px-6 py-5">
     <ModalRenameBoard
       v-show="renameBoardModalVisible"
       @closeModal="renameBoardModalVisible = false"
@@ -48,15 +48,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       @closeModal="changelogModalVisible = false"
     />
 
-    <h1 class="mb-4 text-3xl font-bold">
+    <h1 class="mb-4 text-2xl font-semibold">
       {{ $t('pages.index.welcome') }}
     </h1>
 
     <section id="board-search-and-sort" class="mt-2">
-      <div class="flex max-h-12 w-full flex-row gap-3 pr-2">
+      <div class="flex h-10 w-full flex-row gap-3 pr-2">
         <!-- Search input -->
         <div
-          class="border-elevation-2 bg-elevation-1 supports-[backdrop-filter]:bg-elevation-1/50 focus-within:ring-accent/70 relative w-full rounded-xl border shadow-sm backdrop-blur focus-within:ring-2"
+          class="border-elevation-2 bg-elevation-1 focus-within:border-accent relative w-full rounded-lg border transition-colors"
         >
           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
             <MagnifyingGlassIcon class="text-dim-3 size-5" />
@@ -64,7 +64,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           <input
             v-model="searchQuery"
             :placeholder="searchPlaceholder"
-            class="placeholder:text-dim-3 w-full rounded-xl bg-transparent px-12 py-2 text-lg outline-none"
+            class="placeholder:text-dim-3 size-full rounded-lg bg-transparent px-12 text-sm outline-none"
             type="text"
             aria-label="Search boards"
           >
@@ -85,12 +85,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         >
           <div class="flex max-h-12 items-center gap-2">
             <div
-              class="bg-elevation-1 bg-elevation-2-hover transition-button hide-popper-arrow max-h-12 w-fit rounded-md hover:cursor-pointer"
+              class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button hide-popper-arrow h-10 w-fit rounded-lg border hover:cursor-pointer"
             >
               <Dropdown>
                 <template #trigger>
-                  <button class="flex max-h-12 min-w-48 flex-row items-center gap-2 whitespace-nowrap px-6 py-4 md:min-w-56">
-                    <PhFunnel class="size-6 shrink-0" />
+                  <button class="flex h-10 min-w-48 flex-row items-center gap-2 whitespace-nowrap px-3 text-sm md:min-w-52">
+                    <PhFunnel class="size-4 shrink-0" />
                     <span class="flex-1 overflow-hidden text-ellipsis text-left">{{ sortingOptionText }}</span>
                     <ChevronDownIcon class="size-4 shrink-0" />
                   </button>
@@ -192,7 +192,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         </div>
       </div>
 
-      <div v-else class="mb-8 mt-6 flex flex-row flex-wrap gap-6">
+      <div v-else class="mb-8 mt-5 flex flex-row flex-wrap gap-4">
         <!-- No results for current search -->
         <div
           v-if="!loading && searchQuery && visibleBoards?.length === 0"
@@ -203,7 +203,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
         <TransitionGroup
           v-if="!loading && visibleBoards!.length > 0"
-          class="flex flex-row flex-wrap gap-6"
+          class="flex flex-row flex-wrap gap-4"
           name="list"
           tag="div"
         >
@@ -212,7 +212,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             id="board-preview"
             :key="board.id"
             :to="'/kanban/' + board.id"
-            class="bg-board-preview border-elevation-1 flex flex-col rounded-md border-2 shadow-xl transition-transform hover:-translate-y-1"
+            class="board-preview-tile bg-board-preview border-elevation-2 flex flex-col rounded-lg border"
           >
             <LazyKanbanBoardPreview
               :board="board"
@@ -487,12 +487,14 @@ const exportBoardToJson = async (id: string) => {
 <style scoped>
 .list-move,
 .list-leave-active {
-  transition: all 0.5s ease;
+  transition:
+    opacity 180ms cubic-bezier(0.4, 1, 0.6, 1),
+    transform 200ms cubic-bezier(0.4, 0, 0, 1);
 }
 
 .list-leave-to {
   opacity: 0;
-  transform: translateX(30px);
+  transform: translateY(4px) scale(0.99);
 }
 
 .list-leave-active {
@@ -500,10 +502,19 @@ const exportBoardToJson = async (id: string) => {
 }
 
 .bg-board-preview {
-  background: radial-gradient(
-    circle at bottom left,
-    var(--elevation-1) 30%,
-    transparent
-  );
+  background-color: var(--elevation-1);
+}
+
+.board-preview-tile {
+  transition:
+    border-color 120ms cubic-bezier(0.4, 1, 0.6, 1),
+    box-shadow 120ms cubic-bezier(0.4, 1, 0.6, 1),
+    transform 120ms cubic-bezier(0.4, 1, 0.6, 1);
+}
+
+.board-preview-tile:hover {
+  border-color: color-mix(in srgb, var(--elevation-3) 82%, var(--accent));
+  box-shadow: 0 12px 28px -24px rgba(0, 0, 0, 0.72);
+  transform: translateY(-1px);
 }
 </style>

--- a/pages/kanban/[id].vue
+++ b/pages/kanban/[id].vue
@@ -98,40 +98,65 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
     <div class="bg-custom pointer-events-none absolute inset-0" :style="cssVars" />
 
-    <div class="absolute top-4 z-50 ml-8 w-[calc(100vw-112px)]">
-      <h1
-        v-if="!boardTitleEditing"
-        class="mb-1 max-h-12 w-full overflow-hidden break-words rounded-md bg-transparent py-1 pr-8 text-4xl font-bold"
-        :class="[boardTitleColor]"
-        @click="enableBoardTitleEditing()"
-      >
-        {{ boardContent?.title }}
-      </h1>
-      <input
-        v-if="boardTitleEditing"
-        v-model="boardContent.title"
-        v-focus
-        class="bg-elevation-2 border-accent text-no-overflow -ml-2 mb-1 mr-2 h-12 w-min rounded-sm border-2 border-dotted px-2 text-4xl font-bold outline-none"
-        maxlength="500"
-        type="text"
-        @blur="
-          boardTitleEditing = false;
-          board.updateBoardPin();
-        "
-        @keypress.enter="
-          boardTitleEditing = false;
-          board.updateBoardPin();
-        "
-      >
+    <div class="kanban-board-header absolute top-4 z-50 ml-8 w-[calc(100vw-112px)]">
+      <div class="mb-1 flex max-w-full flex-col gap-2 pr-8 xl:flex-row xl:items-center">
+        <h1
+          v-if="!boardTitleEditing"
+          class="max-h-11 min-w-0 overflow-hidden break-words rounded-md bg-transparent py-1 text-3xl font-semibold"
+          :class="[boardTitleColor]"
+          @click="enableBoardTitleEditing()"
+        >
+          {{ boardContent?.title }}
+        </h1>
+        <input
+          v-if="boardTitleEditing"
+          v-model="boardContent.title"
+          v-focus
+          class="bg-elevation-2 border-accent text-no-overflow -ml-2 mr-2 h-11 w-min rounded-md border px-2 text-3xl font-semibold outline-none"
+          maxlength="500"
+          type="text"
+          @blur="
+            boardTitleEditing = false;
+            board.updateBoardPin();
+          "
+          @keypress.enter="
+            boardTitleEditing = false;
+            board.updateBoardPin();
+          "
+        >
+
+        <div
+          class="board-progress flex w-full max-w-sm shrink-0 items-center rounded-lg px-3 py-2 xl:w-80"
+          :aria-label="`Progress ${boardProgress.percentage} percent, ${boardProgress.done} of ${boardProgress.total} tasks done`"
+          :title="`Done ${boardProgress.done}/${boardProgress.total} (${boardProgress.percentage}%)`"
+        >
+          <div class="flex min-w-0 flex-1 flex-col gap-1.5">
+            <div class="flex items-center justify-between gap-3 text-[11px] font-medium">
+              <span class="text-dim-2 truncate">
+                Done {{ boardProgress.done }}/{{ boardProgress.total }}
+              </span>
+              <span class="shrink-0 tabular-nums text-emerald-500">
+                {{ boardProgress.percentage }}%
+              </span>
+            </div>
+            <div class="board-progress-track relative h-1.5 overflow-hidden rounded-full">
+              <div
+                class="board-progress-fill"
+                :style="{ width: `${boardProgress.percentage}%` }"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div class="flex w-full flex-row justify-between gap-6 xl:gap-0">
         <div class="flex flex-row gap-2">
           <div class="flex flex-row gap-2">
             <button
-              class="bg-elevation-1 bg-elevation-2-hover transition-button flex flex-row gap-1 rounded-md px-4 py-1"
+              class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex flex-row gap-1 rounded-md border px-3 py-1.5"
               @click="showCustomBgModal = true"
             >
-              <PhotoIcon class="my-auto size-6" />
+              <PhotoIcon class="my-auto size-5" />
               <span class="my-auto ml-0.5 hidden lg:block">
                 {{ $t("pages.kanban.changeBackground") }}
               </span>
@@ -139,10 +164,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           </div>
           <div class="flex flex-row gap-2">
             <button
-              class="bg-elevation-1 bg-elevation-2-hover transition-button flex flex-row gap-1 rounded-md px-4 py-1"
+              class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex flex-row gap-1 rounded-md border px-3 py-1.5"
               @click="editTagModalVisible = true"
             >
-              <PhHashStraight class="my-auto size-6" />
+              <PhHashStraight class="my-auto size-5" />
               <span class="my-auto ml-0.5 hidden lg:block">
                 {{ $t("pages.kanban.editTags") }}
               </span>
@@ -158,10 +183,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
           <Dropdown align="end">
             <template #trigger>
               <button
-              class="bg-elevation-1 bg-elevation-2-hover transition-button h-full rounded-md p-2"
+              class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button h-full rounded-md border p-2"
               @click.prevent
               >
-              <EllipsisHorizontalIcon class="size-6" />
+              <EllipsisHorizontalIcon class="size-5" />
               </button>
             </template>
 
@@ -231,7 +256,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
             <Container
               non-drag-area-selector="nodrag"
               orientation="horizontal"
-              class="flex-row gap-2"
+              class="flex-row gap-3"
+              drop-class="kanban-column-drop-target"
               drag-handle-selector=".dragging-handle"
               group-name="columns"
               :get-ghost-parent="getGhostParent"
@@ -249,6 +275,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                     draggingEnabled ? 'dragging-handle' : 'nomoredragging'
                   "
                   :col-index="index"
+                  :has-next-column="index < boardContent.columns.length - 1"
+                  :include-in-unified-todo="column.includeInUnifiedTodo"
                   :title="column.title"
                   :zoom-level="columnZoomLevel"
                   :add-to-top-button-shown="addToTopOfColumnButtonEnabled"
@@ -267,13 +295,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
                   @updateCardTags="board.setCardTags"
                   @updateColumnTitle="board.setColumnTitle"
                   @setCardName="board.setCardName"
+                  @setCardTasks="board.setCardTasks"
+                  @setCardScheduledWeekday="board.setCardScheduledWeekday"
                   @duplicateCard="board.duplicateCard"
+                  @moveCardToNextColumn="board.moveCardToNextColumn"
                   @reorderCards="board.reorderCards"
+                  @setColumnUnifiedTodoInclusion="board.setColumnUnifiedTodoInclusion"
                 />
               </Draggable>
               <div class="pr-8">
                 <div
-                  class="nodrag bg-elevation-1 bg-elevation-2-hover mr-8 flex h-min cursor-pointer flex-row items-center gap-2 rounded-md p-2"
+                  class="nodrag bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button mr-8 flex h-min cursor-pointer flex-row items-center gap-2 rounded-lg border p-2 shadow-sm"
                   @click="board.addColumn()"
                 >
                   <PlusIcon class="text-accent size-6" />
@@ -310,6 +342,7 @@ import { Container, Draggable } from "vue3-smooth-dnd";
 import { useI18n } from "vue-i18n";
 import { useBoard } from "@/composables/useBoard";
 import { useBackgroundImage } from "@/composables/useBackgroundImage";
+import { calculateBoardProgress } from "@/utils/boardProgress";
 
 const route = useRoute();
 const router = useRouter();
@@ -355,6 +388,7 @@ const allColumnCardsRemoveDialog = useConfirmDialog(removeAllColumnCardsModalVis
 
 const board = useBoard(computed(() => route.params.id as string));
 const { board: boardContent } = board;
+const boardProgress = computed(() => calculateBoardProgress(boardContent.value));
 const {
   bgCustom,
   showCustomBgModal,
@@ -581,9 +615,12 @@ const removeCardWithConfirmation = async (
   cardId: string | undefined,
   cardRef: Ref<HTMLElement | null>
 ) => {
-  const cards = boardContent.value?.columns.filter((obj: Column) => {
-    return obj.id === columnId;
-  })[0].cards;
+  const column = boardContent.value?.columns.find(
+    (obj: Column) => obj.id === columnId
+  );
+  if (!column) return;
+
+  const cards = column.cards;
 
   const cardIndex = cards.findIndex((c) => c.id === cardId);
   if (cardIndex === -1) {
@@ -617,12 +654,11 @@ const removeCardWithConfirmation = async (
   emitter.emit("columnDraggingOn");
 };
 
-const removeAllColumnCards = async (
-    columnID: string
-) => {
-  const column = boardContent.value?.columns.filter((obj: Column) => {
-    return obj.id === columnID;
-  })[0];
+const removeAllColumnCards = async (columnID: string) => {
+  const column = boardContent.value?.columns.find(
+    (obj: Column) => obj.id === columnID
+  );
+  if (!column) return;
   
   emitter.emit("openModalWithCustomDescription", {
     description: t("components.kanban.card.deleteAllColumnCardsConfirmation", {
@@ -636,7 +672,7 @@ const removeAllColumnCards = async (
       board.deleteAllColumnCards(columnID);
     }, 250);
   }
-}
+};
 
 /**
  * Utility methods for creating, deleting and updating columns
@@ -644,9 +680,11 @@ const removeAllColumnCards = async (
  */
 
 const openColumnRemoveDialog = async (columnID: string) => {
-  const column = boardContent.value.columns.filter((obj: Column) => {
-    return obj.id === columnID;
-  })[0];
+  const column = boardContent.value?.columns.find(
+    (obj: Column) => obj.id === columnID
+  );
+  if (!column) return;
+
   emitter.emit("openModalWithCustomDescription", {
     description: t("components.kanban.column.deleteColumnConfirmation", {
       columnName: column.title,
@@ -758,12 +796,45 @@ const getGhostParent = () => {
   height: 100vh;
 }
 
+.kanban-board-header {
+  text-shadow: 0 1px 18px color-mix(in srgb, var(--bg-primary) 40%, transparent);
+}
+
+:deep(.kanban-column-drop-target) {
+  border-radius: 0.75rem;
+  outline: 1px dashed color-mix(in srgb, var(--accent) 72%, transparent);
+  outline-offset: 4px;
+}
+
+.board-progress {
+  border: 1px solid color-mix(in srgb, var(--elevation-3) 72%, transparent);
+  background-color: color-mix(in srgb, var(--elevation-1) 92%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.board-progress-track {
+  background-color: color-mix(in srgb, var(--elevation-3) 84%, black 16%);
+}
+
+.board-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: 9999px;
+  background-color: #22c55e;
+  transition: width 200ms cubic-bezier(0.4, 1, 0.6, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board-progress-fill {
+    transition: none;
+  }
+}
+
 .bg-custom {
   filter:
     blur(var(--blur-intensity))
     brightness(var(--bg-brightness));
-    
-    transition: filter 0.5s cubic-bezier(0.17, 0.67, 0.83, 0.67);
+  transition: filter 240ms cubic-bezier(0.16, 1, 0.3, 1);
   background-image: var(--bg-custom-image);
   background-repeat: no-repeat;
   background-size: cover;

--- a/pages/quick-add.vue
+++ b/pages/quick-add.vue
@@ -1,0 +1,187 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<template>
+  <div class="min-h-screen overflow-auto p-6 lg:px-10">
+    <main class="mx-auto flex max-w-5xl flex-col gap-6">
+      <header>
+        <div class="text-dim-2 mb-1 flex items-center gap-1.5">
+          <PhPlusCircle class="size-4" />
+          <span class="text-xs font-medium">
+            {{ $t("quickAdd.eyebrow") }}
+          </span>
+        </div>
+        <h1 class="text-2xl font-semibold">
+          {{ $t("quickAdd.title") }}
+        </h1>
+      </header>
+
+      <section class="bg-elevation-1 border-elevation-3 rounded-lg border p-4">
+        <p class="text-dim-2 mb-1 text-sm">
+          {{ $t("quickAdd.currentTab") }}
+        </p>
+        <h2 class="break-words text-xl font-semibold">
+          {{ sourceTitle }}
+        </h2>
+        <p class="text-dim-2 mt-1 break-all text-sm">
+          {{ sourceUrl || $t("quickAdd.missingUrl") }}
+        </p>
+        <p v-if="!urlSupported" class="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm text-white">
+          {{ $t("quickAdd.unsupportedUrl") }}
+        </p>
+      </section>
+
+      <section>
+        <div class="mb-3 flex items-center justify-between gap-4">
+          <h2 class="text-lg font-semibold">
+            {{ $t("quickAdd.chooseBoard") }}
+          </h2>
+          <span class="text-dim-2 text-xs tabular-nums">
+            {{ boards.length }}
+          </span>
+        </div>
+
+        <div
+          v-if="boards.length === 0 && !loading"
+          class="bg-elevation-1 border-elevation-3 rounded-lg border p-6 text-center"
+        >
+          {{ $t("quickAdd.noBoards") }}
+        </div>
+
+        <div v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <button
+            v-for="board in boards"
+            :key="board.id"
+            type="button"
+            :disabled="!urlSupported || savingBoardId === board.id"
+            class="quick-add-board-card bg-elevation-1 border-elevation-3 bg-elevation-2-hover flex min-h-28 flex-col items-start justify-between rounded-lg border p-4 text-left disabled:cursor-not-allowed disabled:opacity-50"
+            @click="saveToBoard(board.id)"
+          >
+            <span class="break-words text-lg font-semibold">
+              {{ board.title }}
+            </span>
+            <span class="text-dim-2 text-sm">
+              {{ targetColumnLabel(board) }}
+            </span>
+          </button>
+        </div>
+      </section>
+
+      <div
+        v-if="statusMessage"
+        class="bg-elevation-1 border-elevation-3 flex items-center justify-between gap-3 rounded-lg border p-4"
+      >
+        <span>{{ statusMessage }}</span>
+        <nuxt-link
+          v-if="savedBoardId"
+          class="bg-accent text-buttons rounded-md px-4 py-2 text-sm font-semibold"
+          :to="`/kanban/${savedBoardId}`"
+        >
+          {{ $t("quickAdd.openBoard") }}
+        </nuxt-link>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Board } from "@/types/kanban-types";
+import { PhPlusCircle } from "@phosphor-icons/vue";
+import {
+  createQuickAddCard,
+  findQuickAddTargetColumn,
+  isSupportedSourceUrl,
+} from "@/utils/quickAdd";
+
+const route = useRoute();
+const { t } = useI18n();
+const boardsStore = useBoardsStore();
+const layoutStore = useLayoutStore();
+const { boards } = storeToRefs(boardsStore);
+
+const loading = ref(true);
+const savingBoardId = ref<string | null>(null);
+const savedBoardId = ref<string | null>(null);
+const statusMessage = ref("");
+
+const queryString = (value: unknown) =>
+  Array.isArray(value) ? String(value[0] ?? "") : String(value ?? "");
+
+const sourceTitle = computed(() => {
+  const title = queryString(route.query.title).trim();
+  return title || t("quickAdd.untitledPage");
+});
+const sourceUrl = computed(() => queryString(route.query.url).trim());
+const urlSupported = computed(() => isSupportedSourceUrl(sourceUrl.value));
+
+onMounted(async () => {
+  layoutStore.onHomePageLeave();
+  await boardsStore.init();
+  loading.value = false;
+});
+
+const ensureTargetColumnId = (board: Board) => {
+  let targetColumn = findQuickAddTargetColumn(board);
+  if (targetColumn) return targetColumn.id;
+
+  boardsStore.addColumn(board.id, "Idea");
+  targetColumn = findQuickAddTargetColumn(board);
+  return targetColumn?.id ?? null;
+};
+
+const targetColumnLabel = (board: Board) => {
+  const targetColumn = findQuickAddTargetColumn(board);
+  return targetColumn
+    ? t("quickAdd.targetColumn", { column: targetColumn.title })
+    : t("quickAdd.newIdeaColumn");
+};
+
+const saveToBoard = async (boardId: string) => {
+  if (!urlSupported.value) return;
+
+  const board = boardsStore.boardById(boardId);
+  if (!board) return;
+
+  savingBoardId.value = boardId;
+  statusMessage.value = "";
+
+  const columnId = ensureTargetColumnId(board);
+  if (!columnId) {
+    savingBoardId.value = null;
+    statusMessage.value = t("quickAdd.saveFailed");
+    return;
+  }
+
+  boardsStore.createCard(
+    board.id,
+    columnId,
+    createQuickAddCard({
+      title: sourceTitle.value,
+      url: sourceUrl.value,
+    }),
+    true
+  );
+  await boardsStore.save();
+
+  savedBoardId.value = board.id;
+  savingBoardId.value = null;
+  statusMessage.value = t("quickAdd.saved", { board: board.title });
+};
+</script>
+
+<style scoped>
+.quick-add-board-card {
+  transition:
+    background-color var(--motion-fast) var(--motion-ease-interaction),
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.quick-add-board-card:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--elevation-3) 70%, var(--accent));
+  box-shadow: 0 14px 30px -24px rgba(0, 0, 0, 0.65);
+  transform: translateY(-1px);
+}
+</style>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 
 <template>
-  <main id="settings" class="overflow-auto pl-8 pt-6">
+  <main id="settings" class="h-screen overflow-auto px-6 py-5">
     <ModalConfirmation
       v-show="deleteBoardModalVisible"
       :close-button-text="$t('general.cancelAction')"
@@ -32,7 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
       @confirmAction="deleteAllData"
     />
 
-    <h1 class="text-4xl font-bold">
+    <h1 class="text-2xl font-semibold">
       {{ $t("pages.settings.settingsHeading") }}
     </h1>
     <span class="text-dim-3">{{
@@ -40,37 +40,37 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     }}</span>
 
     <section id="theme-settings">
-      <h2 class="mb-2 mt-6 text-2xl font-bold">
+      <h2 class="mb-2 mt-5 text-lg font-semibold">
         {{ $t("pages.settings.sectionThemeHeading") }}
       </h2>
       <div v-if="!theme.autoThemeEnabled" id="theme-selection" class="flex flex-row gap-4">
         <div
-          class="bg-elevation-1 bg-elevation-2-hover flex min-w-36 cursor-pointer flex-col items-center justify-center rounded-md p-2 text-xl font-semibold"
+          class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex min-w-32 cursor-pointer flex-col items-center justify-center rounded-lg border p-3 text-sm font-medium"
           @click="setTheme('light')"
         >
-          <SunIcon :class="themeIconClass('light')" class="size-8" />
+          <SunIcon :class="themeIconClass('light')" class="size-6" />
           <label class="cursor-pointer" for="light-mode-icon">{{
             $t("pages.settings.lightThemeOption")
           }}</label>
         </div>
 
         <div
-          class="bg-elevation-1 bg-elevation-2-hover flex min-w-36 cursor-pointer flex-col items-center justify-center rounded-md p-2 text-xl font-semibold"
+          class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex min-w-32 cursor-pointer flex-col items-center justify-center rounded-lg border p-3 text-sm font-medium"
           @click="setTheme('dark')"
         >
-          <MoonIcon :class="themeIconClass('dark')" class="size-8" />
+          <MoonIcon :class="themeIconClass('dark')" class="size-6" />
           <label class="cursor-pointer" for="dark-mode-icon">{{
             $t("pages.settings.darkThemeOption")
           }}</label>
         </div>
 
         <div
-          class="bg-elevation-1 bg-elevation-2-hover flex min-w-36 cursor-pointer flex-col items-center justify-center rounded-md p-2 text-xl font-semibold"
+          class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex min-w-32 cursor-pointer flex-col items-center justify-center rounded-lg border p-3 text-sm font-medium"
           @click="setTheme('catppuccin')"
         >
           <IconCatppuccin
             :class="themeIconClass('catppuccin')"
-            class="size-8"
+            class="size-6"
           />
           <label class="cursor-pointer" for="catppuccin-mode-icon">{{
             $t("pages.settings.catppuccinThemeOption")
@@ -78,10 +78,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
         </div>
 
         <div
-          class="bg-elevation-1 bg-elevation-2-hover flex min-w-36 cursor-pointer flex-col items-center justify-center rounded-md p-2 text-xl font-semibold"
+          class="bg-elevation-1 bg-elevation-2-hover border-elevation-2 transition-button flex min-w-32 cursor-pointer flex-col items-center justify-center rounded-lg border p-3 text-sm font-medium"
           @click="setTheme('custom')"
         >
-          <SwatchIcon :class="themeIconClass('custom')" class="size-8" />
+          <SwatchIcon :class="themeIconClass('custom')" class="size-6" />
           <label class="cursor-pointer" for="custom-mode-icon">{{
             $t("pages.settings.customThemeOption")
           }}</label>
@@ -146,7 +146,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     </section>
 
     <section id="kanban-settings">
-      <h2 class="mt-8 text-2xl font-bold">
+      <h2 class="mt-8 text-lg font-semibold">
         {{ $t("pages.settings.preferencesHeading") }}
       </h2>
       <span class="text-dim-3 mb-2">{{
@@ -339,7 +339,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
 import type { ThemeIdentifiers } from "@/types/kanban-types";
 
 import { kanriThemeSchema } from "@/types/json-schemas";
-import emitter from "@/utils/emitter";
 import { catppuccin, dark, light } from "@/utils/themes";
 import {
   ArrowDownTrayIcon,

--- a/pages/unified-todo.vue
+++ b/pages/unified-todo.vue
@@ -1,0 +1,395 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<template>
+  <div class="min-h-screen p-6 lg:px-10">
+    <ModalCardTags
+      v-if="activeBoard"
+      v-show="editTagModalVisible"
+      :tags="activeBoard.globalTags ?? []"
+      @closeModal="editTagModalVisible = false"
+      @removeTag="removeGlobalTag"
+      @setTagColor="setGlobalTagColor"
+      @updateTagName="updateGlobalTagName"
+    />
+    <ModalEditCard
+      v-show="editCardModalVisible"
+      :card="activeItem?.card ?? null"
+      :column-id="activeItem?.columnId ?? ''"
+      :global-tags="activeBoard?.globalTags ?? []"
+      @addGlobalTag="addGlobalTag"
+      @closeModal="closeEditCardModal"
+      @openTagEdit="editTagModalVisible = true"
+      @setCardColor="setCardColor"
+      @setCardDescription="setCardDescription"
+      @setCardDueDate="setCardDueDate"
+      @setCardTags="setCardTags"
+      @setCardTasks="setCardTasks"
+      @setCardTitle="setCardTitle"
+    />
+
+    <header class="mx-auto mb-6 flex max-w-6xl flex-col justify-between gap-4 sm:flex-row sm:items-end">
+      <div>
+        <div class="text-dim-2 mb-1 flex items-center gap-1.5">
+          <PhListChecks class="size-4" />
+          <span class="text-xs font-medium">
+            {{ $t("unifiedTodo.eyebrow") }}
+          </span>
+        </div>
+        <h1 class="text-2xl font-semibold">
+          {{ $t("unifiedTodo.title") }}
+        </h1>
+        <p class="text-dim-2 mt-1 max-w-2xl text-sm">
+          {{ $t("unifiedTodo.description") }}
+        </p>
+      </div>
+
+      <label class="flex min-w-52 flex-col gap-1 text-sm">
+        <span class="text-dim-2 flex items-center gap-1.5">
+          <PhFunnel class="size-4" />
+          {{ $t("unifiedTodo.boardFilter") }}
+        </span>
+        <select
+          v-model="selectedBoardId"
+          class="bg-elevation-1 border-elevation-2 focus:border-accent h-9 rounded-md border px-3 text-sm outline-none"
+        >
+          <option value="all">
+            {{ $t("unifiedTodo.allBoards") }}
+          </option>
+          <option v-for="board in boards" :key="board.id" :value="board.id">
+            {{ board.title }}
+          </option>
+        </select>
+      </label>
+    </header>
+
+    <main class="mx-auto max-w-6xl">
+      <div
+        v-if="!loading && visibleGroups.length === 0"
+        class="bg-elevation-1 border-elevation-2 flex min-h-48 flex-col items-center justify-center rounded-lg border p-8 text-center"
+      >
+        <PhCheckCircle class="text-accent mb-4 size-12" />
+        <h2 class="text-xl font-semibold">
+          {{ emptyStateText }}
+        </h2>
+      </div>
+
+      <div v-else class="flex flex-col gap-6">
+        <section v-for="group in visibleGroups" :key="group.boardId">
+          <div class="mb-3 flex items-center justify-between">
+            <h2 class="text-lg font-semibold">{{ group.boardTitle }}</h2>
+            <span class="text-dim-2 text-xs tabular-nums">
+              {{ group.items.length }}
+            </span>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <article
+              v-for="item in group.items"
+              :key="`${item.boardId}-${item.columnId}-${item.card.id}`"
+              class="unified-task-card bg-elevation-1 border-elevation-3 bg-elevation-2-hover group relative flex overflow-hidden rounded-lg border shadow-sm"
+            >
+              <div
+                :class="cardColorClass(item.card.color)"
+                :style="cardColorStyle(item.card.color)"
+                class="w-1.5 shrink-0"
+              />
+
+              <CheckboxRoot
+                :checked="false"
+                :disabled="!canMoveRight(item)"
+                :aria-label="canMoveRight(item)
+                  ? $t('unifiedTodo.markDone')
+                  : $t('unifiedTodo.noNextColumn')"
+                :title="canMoveRight(item)
+                  ? $t('unifiedTodo.markDone')
+                  : $t('unifiedTodo.noNextColumn')"
+                class="bg-elevation-4 bg-elevation-2-hover border-elevation-5 ml-4 mt-5 flex size-5 shrink-0 appearance-none items-center justify-center rounded-[4px] border outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                @click.stop
+                @update:checked="(checked) => markDone(item, checked)"
+              >
+                <CheckboxIndicator class="flex size-full items-center justify-center rounded">
+                  <PhCheck weight="bold" class="text-accent-lighter size-4" />
+                </CheckboxIndicator>
+              </CheckboxRoot>
+
+              <button
+                class="flex min-w-0 flex-1 flex-col items-start gap-3 p-4 text-left"
+                type="button"
+                @click="openEditCardModal(item)"
+              >
+                <div class="flex w-full flex-col justify-between gap-2 sm:flex-row sm:items-start">
+                  <h3 class="break-words text-lg font-medium">
+                    {{ item.card.name }}
+                  </h3>
+                  <div class="text-dim-2 flex shrink-0 items-center gap-1 text-sm">
+                    <span>{{ item.columnTitle }}</span>
+                    <PhCaretRight class="size-4" />
+                    <span>{{ nextColumnTitle(item) }}</span>
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="bg-elevation-2 rounded px-2 py-0.5 text-xs">
+                    {{ item.boardTitle }} · {{ item.columnTitle }}
+                  </span>
+                  <span
+                    v-if="isPlannedColumnTitle(item.columnTitle) && item.card.scheduledWeekday"
+                    class="rounded border px-2 py-0.5 text-xs font-semibold"
+                    :style="plannedWeekdayStyleFor(item.card.scheduledWeekday)"
+                  >
+                    {{ item.card.scheduledWeekday }}
+                  </span>
+                  <KanbanTagDisplay
+                    v-for="tag in item.card.tags ?? []"
+                    :key="tag.id ?? tag.text"
+                    :tag="tag"
+                    :zoom-level="0"
+                  />
+                  <span
+                    v-if="item.card.dueDate"
+                    class="text-dim-2 flex items-center gap-1 text-sm"
+                  >
+                    <PhClock class="size-4" />
+                    {{ formatDueDate(item.card.dueDate) }}
+                  </span>
+                </div>
+              </button>
+
+              <button
+                v-if="item.card.sourceUrl"
+                type="button"
+                class="text-dim-2 bg-elevation-2-hover mr-4 mt-5 flex max-w-48 shrink-0 items-center gap-1 self-start rounded-sm px-2 py-1 text-sm"
+                :title="item.card.sourceUrl"
+                @click.stop="openSourceUrl(item.card.sourceUrl)"
+              >
+                <PhLinkSimple class="size-4" />
+                <span class="truncate">
+                  {{ item.card.sourceTitle || item.card.sourceUrl }}
+                </span>
+              </button>
+            </article>
+          </div>
+        </section>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Card, Tag, Task } from "@/types/kanban-types";
+import type { UnifiedTodoItem } from "@/utils/unifiedTodo";
+import {
+  isPlannedColumnTitle,
+  plannedWeekdayStyleFor,
+} from "@/utils/plannedWeekday";
+import {
+  PhCaretRight,
+  PhCheck,
+  PhCheckCircle,
+  PhClock,
+  PhFunnel,
+  PhLinkSimple,
+  PhListChecks,
+} from "@phosphor-icons/vue";
+import { openSourceLink } from "@/utils/sourceLinks";
+
+const boardsStore = useBoardsStore();
+const layoutStore = useLayoutStore();
+const { boards, unifiedTodoItems } = storeToRefs(boardsStore);
+const { locale, t } = useI18n();
+
+const loading = ref(true);
+const selectedBoardId = ref("all");
+const editCardModalVisible = ref(false);
+const editTagModalVisible = ref(false);
+const activeItem = ref<UnifiedTodoItem | null>(null);
+
+const activeBoard = computed(() => {
+  if (!activeItem.value) return null;
+  return boardsStore.boardById(activeItem.value.boardId);
+});
+
+const filteredItems = computed(() => {
+  if (selectedBoardId.value === "all") return unifiedTodoItems.value;
+  return unifiedTodoItems.value.filter(
+    item => item.boardId === selectedBoardId.value
+  );
+});
+
+const visibleGroups = computed(() => {
+  const groups = new Map<
+    string,
+    { boardId: string; boardTitle: string; items: UnifiedTodoItem[] }
+  >();
+
+  for (const item of filteredItems.value) {
+    const group = groups.get(item.boardId);
+    if (group) {
+      group.items.push(item);
+    } else {
+      groups.set(item.boardId, {
+        boardId: item.boardId,
+        boardTitle: item.boardTitle,
+        items: [item],
+      });
+    }
+  }
+
+  return [...groups.values()];
+});
+
+const emptyStateText = computed(() => {
+  if (selectedBoardId.value !== "all") {
+    return t("unifiedTodo.noFilterMatches");
+  }
+
+  return t("unifiedTodo.noTasks");
+});
+
+onMounted(async () => {
+  layoutStore.onHomePageLeave();
+  await boardsStore.init();
+  loading.value = false;
+});
+
+const boardAndColumnIndex = (item: UnifiedTodoItem) => {
+  const board = boardsStore.boardById(item.boardId);
+  const columnIndex = board?.columns.findIndex(
+    column => column.id === item.columnId
+  ) ?? -1;
+
+  return { board, columnIndex };
+};
+
+const canMoveRight = (item: UnifiedTodoItem) => {
+  const { board, columnIndex } = boardAndColumnIndex(item);
+  return Boolean(board && columnIndex >= 0 && columnIndex < board.columns.length - 1);
+};
+
+const nextColumnTitle = (item: UnifiedTodoItem) => {
+  const { board, columnIndex } = boardAndColumnIndex(item);
+  return board?.columns[columnIndex + 1]?.title ?? t("unifiedTodo.lastColumn");
+};
+
+const markDone = (
+  item: UnifiedTodoItem,
+  checked: boolean | "indeterminate"
+) => {
+  if (checked !== true || !item.card.id) return;
+  boardsStore.moveCardToNextColumn(item.boardId, item.columnId, item.card.id);
+};
+
+const openEditCardModal = (item: UnifiedTodoItem) => {
+  activeItem.value = item;
+  editCardModalVisible.value = true;
+};
+
+const openSourceUrl = async (sourceUrl: string) => {
+  await openSourceLink(sourceUrl);
+};
+
+const closeEditCardModal = () => {
+  editCardModalVisible.value = false;
+};
+
+const mutateActiveCard = (
+  columnId: string,
+  cardId: string | undefined,
+  mutation: (card: Card) => void
+) => {
+  if (!activeItem.value || !cardId) return;
+  boardsStore.mutateCard(activeItem.value.boardId, columnId, cardId, mutation);
+};
+
+const setCardColor = (
+  columnId: string,
+  cardId: string | undefined,
+  color: string
+) => mutateActiveCard(columnId, cardId, card => { card.color = color; });
+
+const setCardDescription = (
+  columnId: string,
+  cardId: string | undefined,
+  description: string
+) => mutateActiveCard(columnId, cardId, card => { card.description = description; });
+
+const setCardDueDate = (
+  columnId: string,
+  cardId: string | undefined,
+  dueDate: Date | null,
+  isCounterRelative: boolean,
+  isCompleted: boolean
+) => mutateActiveCard(columnId, cardId, card => {
+  card.dueDate = dueDate;
+  card.isDueDateCounterRelative = isCounterRelative;
+  card.isDueDateCompleted = isCompleted;
+});
+
+const setCardTags = (
+  columnId: string,
+  cardId: string | undefined,
+  tags: Tag[]
+) => mutateActiveCard(columnId, cardId, card => { card.tags = tags; });
+
+const setCardTasks = (
+  columnId: string,
+  cardId: string | undefined,
+  tasks: Task[]
+) => mutateActiveCard(columnId, cardId, card => { card.tasks = tasks; });
+
+const setCardTitle = (
+  columnId: string,
+  cardId: string | undefined,
+  title: string
+) => mutateActiveCard(columnId, cardId, card => { card.name = title; });
+
+const addGlobalTag = (tag: Tag) => {
+  if (!activeItem.value) return;
+  boardsStore.addGlobalTag(activeItem.value.boardId, tag);
+};
+
+const removeGlobalTag = (tagId: string) => {
+  if (!activeItem.value) return;
+  boardsStore.removeGlobalTag(activeItem.value.boardId, tagId);
+};
+
+const setGlobalTagColor = (tagId: string, color: string) => {
+  if (!activeItem.value) return;
+  boardsStore.setGlobalTagColor(activeItem.value.boardId, tagId, color);
+};
+
+const updateGlobalTagName = (tagId: string, name: string) => {
+  if (!activeItem.value) return;
+  boardsStore.updateGlobalTagName(activeItem.value.boardId, tagId, name);
+};
+
+const formatDueDate = (dueDate: Date | string) =>
+  new Date(dueDate).toLocaleDateString(locale.value.replace("_", "-"));
+
+const cardColorClass = (color?: string) => {
+  if (!color || color.startsWith("#")) return "bg-accent";
+  return color;
+};
+
+const cardColorStyle = (color?: string) =>
+  color?.startsWith("#") ? { backgroundColor: color } : undefined;
+</script>
+
+<style scoped>
+.unified-task-card {
+  transform: translateZ(0);
+  transition:
+    background-color var(--motion-fast) var(--motion-ease-interaction),
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.unified-task-card:hover {
+  border-color: color-mix(in srgb, var(--elevation-3) 70%, var(--accent));
+  box-shadow: 0 14px 30px -24px rgba(0, 0, 0, 0.65);
+  transform: translateY(-1px);
+}
+</style>

--- a/pages/weekly-calendar.vue
+++ b/pages/weekly-calendar.vue
@@ -1,0 +1,265 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev> -->
+<!-- -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<template>
+  <div class="flex h-screen min-w-0 flex-col overflow-hidden px-6 py-5">
+    <header class="mb-4 flex shrink-0 items-center justify-between gap-4">
+      <div>
+        <div class="text-dim-2 mb-1 flex items-center gap-1.5">
+          <PhCalendarBlank class="size-4" />
+          <span class="text-xs font-medium">
+            {{ $t("weeklyCalendar.eyebrow") }}
+          </span>
+        </div>
+        <h1 class="text-2xl font-semibold">
+          {{ $t("weeklyCalendar.title") }}
+        </h1>
+      </div>
+
+      <div class="text-dim-2 text-xs tabular-nums">
+        {{ plannedItemCount }} {{ $t("weeklyCalendar.plannedTasks") }}
+      </div>
+    </header>
+
+    <main class="flex min-h-0 flex-1 flex-col gap-4">
+      <section class="grid min-h-0 flex-1 grid-cols-7 gap-2">
+        <article
+          v-for="weekday in weekdays"
+          :key="weekday"
+          class="calendar-column bg-elevation-1 border-elevation-2 flex min-w-0 flex-col rounded-lg border p-2"
+        >
+          <header class="mb-2 flex items-center justify-between gap-2">
+            <div
+              class="rounded-md border px-2 py-1 text-sm font-bold"
+              :style="plannedWeekdayStyleFor(weekday)"
+            >
+              {{ weekday }}
+            </div>
+            <span class="bg-elevation-2 text-dim-2 rounded-full px-2 py-0.5 text-xs">
+              {{ calendar.scheduled[weekday].length }}
+            </span>
+          </header>
+
+          <Container
+            class="custom-scrollbar min-h-0 flex-1 overflow-y-auto"
+            drag-class="cursor-grabbing"
+            drop-class="weekly-calendar-drop-target"
+            group-name="weekly-calendar-cards"
+            orientation="vertical"
+            :get-child-payload="(index: number) => calendar.scheduled[weekday][index]"
+            @drop="dropOnWeekday($event, weekday)"
+          >
+            <div
+              v-if="calendar.scheduled[weekday].length === 0"
+              class="text-dim-2 border-elevation-3 flex min-h-24 items-center justify-center rounded-md border border-dashed px-2 text-center text-xs"
+            >
+              {{ $t("weeklyCalendar.dropHere") }}
+            </div>
+
+            <Draggable
+              v-for="item in calendar.scheduled[weekday]"
+              :key="itemKey(item)"
+              class="mb-2"
+            >
+              <article
+                class="weekly-calendar-card bg-elevation-2 border-elevation-3 bg-elevation-3-hover cursor-grab rounded-md border p-2 shadow-sm active:cursor-grabbing"
+              >
+                <p class="line-clamp-3 break-words text-sm font-semibold">
+                  {{ item.card.name }}
+                </p>
+                <p class="text-dim-2 mt-1 truncate text-[11px]">
+                  {{ item.boardTitle }}
+                </p>
+                <button
+                  v-if="item.card.sourceUrl"
+                  type="button"
+                  class="text-dim-2 bg-elevation-3-hover mt-2 flex max-w-full items-center gap-1 rounded-sm px-1 text-[11px]"
+                  :title="item.card.sourceUrl"
+                  @click.stop="openSourceUrl(item.card.sourceUrl)"
+                  @pointerdown.stop
+                >
+                  <PhLinkSimple class="size-3" />
+                  <span class="truncate">
+                    {{ item.card.sourceTitle || item.card.sourceUrl }}
+                  </span>
+                </button>
+              </article>
+            </Draggable>
+          </Container>
+        </article>
+      </section>
+
+      <section
+        class="calendar-column bg-elevation-1 border-elevation-2 flex h-44 shrink-0 flex-col rounded-lg border p-3"
+      >
+        <header class="mb-2 flex shrink-0 items-center justify-between">
+          <div>
+            <h2 class="text-lg font-semibold">
+              {{ $t("weeklyCalendar.unscheduledTitle") }}
+            </h2>
+            <p class="text-dim-2 text-xs">
+              {{ $t("weeklyCalendar.unscheduledHint") }}
+            </p>
+          </div>
+          <span class="bg-elevation-2 text-dim-2 rounded-full px-3 py-1 text-sm">
+            {{ calendar.unscheduled.length }}
+          </span>
+        </header>
+
+        <Container
+          class="custom-scrollbar min-h-0 flex-1 overflow-y-auto"
+          drag-class="cursor-grabbing"
+          drop-class="weekly-calendar-drop-target"
+          group-name="weekly-calendar-cards"
+          orientation="horizontal"
+          :get-child-payload="(index: number) => calendar.unscheduled[index]"
+          @drop="dropOnUnscheduled"
+        >
+          <div
+            v-if="calendar.unscheduled.length === 0"
+            class="text-dim-2 border-elevation-3 flex size-full items-center justify-center rounded-md border border-dashed text-sm"
+          >
+            {{ $t("weeklyCalendar.noUnscheduledTasks") }}
+          </div>
+
+          <Draggable
+            v-for="item in calendar.unscheduled"
+            :key="itemKey(item)"
+            class="mb-2 mr-2 inline-block w-56 align-top"
+          >
+            <article
+              class="weekly-calendar-card bg-elevation-2 border-elevation-3 bg-elevation-3-hover cursor-grab rounded-md border p-2 shadow-sm active:cursor-grabbing"
+            >
+              <p class="line-clamp-2 break-words text-sm font-semibold">
+                {{ item.card.name }}
+              </p>
+              <p class="text-dim-2 mt-1 truncate text-[11px]">
+                {{ item.boardTitle }}
+              </p>
+              <button
+                v-if="item.card.sourceUrl"
+                type="button"
+                class="text-dim-2 bg-elevation-3-hover mt-2 flex max-w-full items-center gap-1 rounded-sm px-1 text-[11px]"
+                :title="item.card.sourceUrl"
+                @click.stop="openSourceUrl(item.card.sourceUrl)"
+                @pointerdown.stop
+              >
+                <PhLinkSimple class="size-3" />
+                <span class="truncate">
+                  {{ item.card.sourceTitle || item.card.sourceUrl }}
+                </span>
+              </button>
+            </article>
+          </Draggable>
+        </Container>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ScheduledWeekday } from "@/types/kanban-types";
+import type { WeeklyCalendarItem } from "@/utils/weeklyCalendar";
+import { PhCalendarBlank, PhLinkSimple } from "@phosphor-icons/vue";
+import {
+  PLANNED_WEEKDAYS,
+  plannedWeekdayStyleFor,
+} from "@/utils/plannedWeekday";
+import { openSourceLink } from "@/utils/sourceLinks";
+import { aggregateWeeklyCalendarItems } from "@/utils/weeklyCalendar";
+//@ts-expect-error, sadly this library does not have ts typings
+import { Container, Draggable } from "vue3-smooth-dnd";
+
+const boardsStore = useBoardsStore();
+const layoutStore = useLayoutStore();
+const { boards } = storeToRefs(boardsStore);
+
+const weekdays = PLANNED_WEEKDAYS;
+
+const calendar = computed(() => aggregateWeeklyCalendarItems(boards.value));
+const plannedItemCount = computed(
+  () =>
+    calendar.value.unscheduled.length +
+    weekdays.reduce(
+      (total, weekday) => total + calendar.value.scheduled[weekday].length,
+      0
+    )
+);
+
+onMounted(async () => {
+  layoutStore.onHomePageLeave();
+  await boardsStore.init();
+});
+
+const itemKey = (item: WeeklyCalendarItem) =>
+  `${item.boardId}-${item.columnId}-${item.card.id ?? item.cardOrder}`;
+
+const setCardWeekday = (
+  item: WeeklyCalendarItem,
+  weekday: ScheduledWeekday | null
+) => {
+  if (!item.card.id) return;
+
+  boardsStore.mutateCard(item.boardId, item.columnId, item.card.id, (card) => {
+    card.scheduledWeekday = weekday;
+  });
+};
+
+const openSourceUrl = async (sourceUrl: string) => {
+  await openSourceLink(sourceUrl);
+};
+
+type CalendarDropResult = {
+  addedIndex: number | null;
+  payload?: WeeklyCalendarItem;
+  removedIndex: number | null;
+};
+
+const dropOnWeekday = (
+  dropResult: CalendarDropResult,
+  weekday: ScheduledWeekday
+) => {
+  if (dropResult.addedIndex === null || !dropResult.payload) return;
+
+  setCardWeekday(dropResult.payload, weekday);
+};
+
+const dropOnUnscheduled = (dropResult: CalendarDropResult) => {
+  if (dropResult.addedIndex === null || !dropResult.payload) return;
+
+  setCardWeekday(dropResult.payload, null);
+};
+</script>
+
+<style scoped>
+.weekly-calendar-card {
+  transform: translateZ(0);
+  transition:
+    opacity var(--motion-fast) var(--motion-ease-interaction),
+    transform var(--motion-fast) var(--motion-ease-interaction),
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.calendar-column {
+  background-color: var(--elevation-1);
+  transition:
+    border-color var(--motion-fast) var(--motion-ease-interaction),
+    box-shadow var(--motion-fast) var(--motion-ease-interaction);
+}
+
+.calendar-column:hover {
+  border-color: var(--elevation-3);
+}
+
+.weekly-calendar-card:hover {
+  border-color: color-mix(in srgb, var(--elevation-3) 84%, var(--accent));
+  box-shadow: 0 8px 20px -20px rgba(0, 0, 0, 0.6);
+  transform: translateY(-1px);
+}
+
+:deep(.weekly-calendar-drop-target) {
+  border-color: var(--accent);
+}
+</style>

--- a/plugins/deepLinks.client.ts
+++ b/plugins/deepLinks.client.ts
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { watch } from "vue";
+import type { Board } from "@/types/kanban-types";
+import {
+  createQuickAddCard,
+  findQuickAddTargetColumn,
+  isSupportedSourceUrl,
+} from "@/utils/quickAdd";
+import {
+  getQuickAddPathFromDeepLink,
+  getQuickAddRouteTarget,
+} from "@/utils/sourceLinks";
+
+type QuickAddPayload = {
+  boardId?: string;
+  title?: string;
+  url?: string;
+};
+
+type QuickAddBoardSummary = {
+  id: string;
+  targetColumn: string;
+  title: string;
+};
+
+export default defineNuxtPlugin(() => {
+  if (!("__TAURI_INTERNALS__" in window)) return;
+
+  const router = useRouter();
+  const boardsStore = useBoardsStore();
+
+  const openQuickAddRoute = (payload: QuickAddPayload) => {
+    void router.push(getQuickAddRouteTarget(payload));
+  };
+
+  const ensureQuickAddTargetColumnId = (board: Board) => {
+    let targetColumn = findQuickAddTargetColumn(board);
+    if (targetColumn) return targetColumn.id;
+
+    boardsStore.addColumn(board.id, "Idea");
+    targetColumn = findQuickAddTargetColumn(board);
+    return targetColumn?.id ?? null;
+  };
+
+  const saveQuickAddToBoard = async (payload: QuickAddPayload) => {
+    const boardId = payload.boardId?.trim();
+    const url = payload.url?.trim() ?? "";
+    if (!boardId || !isSupportedSourceUrl(url)) return false;
+
+    await boardsStore.init();
+    const board = boardsStore.boardById(boardId);
+    if (!board) return false;
+
+    const targetColumnId = ensureQuickAddTargetColumnId(board);
+    if (!targetColumnId) return false;
+
+    boardsStore.createCard(
+      board.id,
+      targetColumnId,
+      createQuickAddCard({
+        title: payload.title ?? "",
+        url,
+      }),
+      true
+    );
+    await boardsStore.save();
+    void router.push(`/kanban/${board.id}`);
+    return true;
+  };
+
+  const quickAddBoardSummaries = (): QuickAddBoardSummary[] =>
+    boardsStore.boards.map((board) => {
+      const targetColumn = findQuickAddTargetColumn(board);
+
+      return {
+        id: board.id,
+        targetColumn: targetColumn?.title ?? "Idea",
+        title: board.title,
+      };
+    });
+
+  const syncQuickAddBoards = async () => {
+    await invoke("set_quick_add_boards", {
+      boards: quickAddBoardSummaries(),
+    });
+  };
+
+  let syncTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleQuickAddBoardSync = () => {
+    if (syncTimer) clearTimeout(syncTimer);
+
+    syncTimer = setTimeout(() => {
+      void syncQuickAddBoards().catch((error) => {
+        console.warn("Quick-add board sync is unavailable:", error);
+      });
+      syncTimer = null;
+    }, 150);
+  };
+
+  const handleDeepLinks = (urls: string[] | null) => {
+    const routeTarget = urls
+      ?.map(getQuickAddPathFromDeepLink)
+      .find(target => target !== null);
+
+    if (!routeTarget) return;
+
+    void router.push(routeTarget);
+  };
+
+  void boardsStore
+    .init()
+    .then(syncQuickAddBoards)
+    .then(() => {
+      watch(
+        () => boardsStore.boards,
+        () => scheduleQuickAddBoardSync(),
+        { deep: true }
+      );
+    })
+    .catch((error) => {
+      console.warn("Quick-add board sync is unavailable:", error);
+    });
+
+  void listen<QuickAddPayload>("quick-add-request", async (event) => {
+    const saved = await saveQuickAddToBoard(event.payload);
+    if (!saved) openQuickAddRoute(event.payload);
+  }).catch((error) => {
+    console.warn("Quick-add bridge handling is unavailable:", error);
+  });
+
+  void getCurrent()
+    .then(handleDeepLinks)
+    .then(() => onOpenUrl(handleDeepLinks))
+    .catch((error) => {
+      console.warn("Deep link handling is unavailable:", error);
+    });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -632,6 +632,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +758,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -945,6 +971,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1621,6 +1656,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2086,6 +2127,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
@@ -2590,6 +2632,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -3290,6 +3342,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4019,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.4.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9946a3cede302eac0c6eb6c6070ac47b1768e326092d32efbb91f21ed58d978f"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
 dependencies = [
  "anyhow",
  "glob",
@@ -4046,6 +4108,27 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.16",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4175,6 +4258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.16",
  "tracing",
  "windows-sys 0.60.2",
@@ -4405,6 +4489,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5199,6 +5292,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ tauri-plugin-dialog = "2.6.0"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-fs = "2.4.2"
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2.4.9"
 
 [features]
 # by default Tauri runs in production mode
@@ -45,5 +46,5 @@ custom-protocol = ["tauri/custom-protocol"]
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-autostart = "2.5.1"
-tauri-plugin-single-instance = "2.4.0"
+tauri-plugin-single-instance = { version = "2.4.0", features = ["deep-link"] }
 tauri-plugin-window-state = { version = "2.4.1" }

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -29,6 +29,12 @@
       "identifier": "opener:allow-open-url",
       "allow": [
         {
+          "url": "http://*"
+        },
+        {
+          "url": "https://*"
+        },
+        {
           "url": "https://kanriapp.com/*"
         },
         {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,9 +9,234 @@
     windows_subsystem = "windows"
 )]
 
-use tauri::Manager;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{Arc, Mutex},
+    thread,
+};
+use tauri::{Emitter, Manager};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_window_state::StateFlags;
+
+const QUICK_ADD_BRIDGE_ADDR: &str = "127.0.0.1:47827";
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuickAddPayload {
+    title: String,
+    url: String,
+    board_id: Option<String>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuickAddBoardSummary {
+    id: String,
+    title: String,
+    target_column: String,
+}
+
+#[derive(Clone, Default)]
+struct QuickAddBridgeState {
+    boards: Arc<Mutex<Vec<QuickAddBoardSummary>>>,
+}
+
+#[tauri::command]
+fn set_quick_add_boards(
+    state: tauri::State<'_, QuickAddBridgeState>,
+    boards: Vec<QuickAddBoardSummary>,
+) {
+    if let Ok(mut cached_boards) = state.boards.lock() {
+        *cached_boards = boards;
+    }
+}
+
+fn header_value<'a>(headers: &'a str, name: &str) -> Option<&'a str> {
+    headers.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        if key.trim().eq_ignore_ascii_case(name) {
+            Some(value.trim())
+        } else {
+            None
+        }
+    })
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Option<(String, Vec<u8>)> {
+    let mut request = Vec::new();
+    let mut header_end = None;
+    let mut content_length = 0usize;
+
+    loop {
+        let mut buffer = [0; 1024];
+        let bytes_read = stream.read(&mut buffer).ok()?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        request.extend_from_slice(&buffer[..bytes_read]);
+
+        if header_end.is_none() {
+            if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&request[..position]).to_string();
+                content_length = header_value(&headers, "content-length")
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(0);
+                header_end = Some(position + 4);
+            }
+        }
+
+        if let Some(end) = header_end {
+            if request.len() >= end + content_length {
+                let headers = String::from_utf8_lossy(&request[..end]).to_string();
+                let body = request[end..end + content_length].to_vec();
+                return Some((headers, body));
+            }
+        }
+
+        if request.len() > 32 * 1024 {
+            return None;
+        }
+    }
+
+    None
+}
+
+fn is_allowed_quick_add_origin(origin: Option<&str>) -> bool {
+    origin
+        .map(|value| value.starts_with("chrome-extension://"))
+        .unwrap_or(true)
+}
+
+fn is_supported_source_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+fn focus_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    status: &str,
+    body: &str,
+    origin: Option<&str>,
+) {
+    let cors_headers = origin
+        .filter(|value| value.starts_with("chrome-extension://"))
+        .map(|value| {
+            format!(
+                "Access-Control-Allow-Origin: {value}\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: content-type\r\n"
+            )
+        })
+        .unwrap_or_default();
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\n{cors_headers}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn handle_quick_add_bridge_stream(
+    mut stream: TcpStream,
+    app: tauri::AppHandle,
+    state: QuickAddBridgeState,
+) {
+    let Some((headers, body)) = read_http_request(&mut stream) else {
+        return;
+    };
+
+    let mut request_parts = headers
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = request_parts.next().unwrap_or_default();
+    let path = request_parts.next().unwrap_or_default();
+    let origin = header_value(&headers, "origin");
+
+    if path != "/quick-add" && path != "/boards" {
+        write_http_response(&mut stream, "404 Not Found", "{\"ok\":false}", origin);
+        return;
+    }
+
+    if !is_allowed_quick_add_origin(origin) {
+        write_http_response(&mut stream, "403 Forbidden", "{\"ok\":false}", origin);
+        return;
+    }
+
+    if method == "OPTIONS" {
+        write_http_response(&mut stream, "204 No Content", "", origin);
+        return;
+    }
+
+    if path == "/boards" {
+        if method != "GET" {
+            write_http_response(
+                &mut stream,
+                "405 Method Not Allowed",
+                "{\"ok\":false}",
+                origin,
+            );
+            return;
+        }
+
+        let boards = state
+            .boards
+            .lock()
+            .map(|cached_boards| cached_boards.clone())
+            .unwrap_or_default();
+        let body = serde_json::json!({ "ok": true, "boards": boards }).to_string();
+        write_http_response(&mut stream, "200 OK", &body, origin);
+        return;
+    }
+
+    if method != "POST" {
+        write_http_response(
+            &mut stream,
+            "405 Method Not Allowed",
+            "{\"ok\":false}",
+            origin,
+        );
+        return;
+    }
+
+    let Ok(payload) = serde_json::from_slice::<QuickAddPayload>(&body) else {
+        write_http_response(&mut stream, "400 Bad Request", "{\"ok\":false}", origin);
+        return;
+    };
+
+    if !is_supported_source_url(&payload.url) {
+        write_http_response(&mut stream, "400 Bad Request", "{\"ok\":false}", origin);
+        return;
+    }
+
+    focus_main_window(&app);
+    let _ = app.emit("quick-add-request", payload);
+    write_http_response(&mut stream, "202 Accepted", "{\"ok\":true}", origin);
+}
+
+fn start_quick_add_bridge(app: tauri::AppHandle, state: QuickAddBridgeState) {
+    thread::spawn(move || {
+        let Ok(listener) = TcpListener::bind(QUICK_ADD_BRIDGE_ADDR) else {
+            return;
+        };
+
+        for stream in listener.incoming().flatten() {
+            let app = app.clone();
+            let state = state.clone();
+            thread::spawn(move || handle_quick_add_bridge_stream(stream, app, state));
+        }
+    });
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -26,7 +251,18 @@ pub fn run() {
         std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     }
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+    let quick_add_bridge_state = QuickAddBridgeState::default();
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            focus_main_window(app);
+        }));
+    }
+
+    builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_fs::init())
@@ -44,17 +280,20 @@ pub fn run() {
             MacosLauncher::LaunchAgent,
             None,
         ))
-        .setup(|app| {
+        .manage(quick_add_bridge_state.clone())
+        .invoke_handler(tauri::generate_handler![set_quick_add_boards])
+        .setup(move |app| {
             #[cfg(desktop)]
-            let _ = app
-                .handle()
-                .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-                    if let Some(window) = app.get_webview_window("main") {
-                        let _ = window.unminimize();
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
-                }));
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+
+                #[cfg(target_os = "macos")]
+                let _ = app.deep_link().register("kanri");
+
+                #[cfg(any(windows, target_os = "linux"))]
+                let _ = app.deep_link().register_all();
+            }
+            start_quick_add_bridge(app.handle().clone(), quick_add_bridge_state.clone());
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,15 @@
   "mainBinaryName": "kanri",
   "version": "0.8.2",
   "identifier": "tech.trobonox.kanri",
-  "plugins": {},
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "kanri"
+        ]
+      }
+    }
+  },
   "app": {
     "windows": [
       {

--- a/stores/boards.spec.ts
+++ b/stores/boards.spec.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useBoardsStore } from "./boards";
+
+describe("boards store task progression", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("moves a card one column to the right and updates Unified To-Do", () => {
+    const store = useBoardsStore();
+    store.boards = [
+      {
+        id: "work",
+        title: "Work",
+        columns: [
+          {
+            id: "todo",
+            title: "To Do",
+            cards: [{ id: "task", name: "Ship feature" }],
+          },
+          { id: "doing", title: "Doing", cards: [] },
+          { id: "done", title: "Done", cards: [] },
+        ],
+      },
+    ];
+
+    expect(store.unifiedTodoItems.map(item => item.card.id)).toEqual(["task"]);
+
+    store.moveCardToNextColumn("work", "todo", "task");
+
+    expect(store.boards[0]?.columns[0]?.cards).toHaveLength(0);
+    expect(store.boards[0]?.columns[1]?.cards[0]?.id).toBe("task");
+    expect(store.unifiedTodoItems).toHaveLength(0);
+  });
+
+  it("leaves cards in the final column in place", () => {
+    const store = useBoardsStore();
+    store.boards = [
+      {
+        id: "work",
+        title: "Work",
+        columns: [
+          {
+            id: "done",
+            title: "Done",
+            cards: [{ id: "finished", name: "Finished" }],
+          },
+        ],
+      },
+    ];
+
+    store.moveCardToNextColumn("work", "done", "finished");
+
+    expect(store.boards[0]?.columns[0]?.cards[0]?.id).toBe("finished");
+  });
+
+  it("updates subtask completion without moving the card", () => {
+    const store = useBoardsStore();
+    store.boards = [
+      {
+        id: "work",
+        title: "Work",
+        columns: [
+          {
+            id: "todo",
+            title: "To Do",
+            cards: [
+              {
+                id: "task",
+                name: "Ship feature",
+                tasks: [{ id: "subtask", name: "Write tests", finished: false }],
+              },
+            ],
+          },
+          { id: "done", title: "Done", cards: [] },
+        ],
+      },
+    ];
+
+    store.mutateCard("work", "todo", "task", (card) => {
+      card.tasks = [{ id: "subtask", name: "Write tests", finished: true }];
+    });
+
+    expect(store.boards[0]?.columns[0]?.cards[0]?.id).toBe("task");
+    expect(store.boards[0]?.columns[0]?.cards[0]?.tasks?.[0]?.finished).toBe(true);
+    expect(store.boards[0]?.columns[1]?.cards).toHaveLength(0);
+  });
+
+  it("adds IDs to legacy cards so Unified To-Do interactions stay connected", () => {
+    const store = useBoardsStore();
+
+    store.upsertBoard({
+      id: "legacy",
+      title: "Legacy",
+      columns: [
+        {
+          id: "todo",
+          title: "To Do",
+          cards: [{ name: "Card without an ID" }],
+        },
+      ],
+    });
+
+    expect(store.boards[0]?.columns[0]?.cards[0]?.id).toBeTypeOf("string");
+    expect(store.unifiedTodoItems[0]?.card).toBe(
+      store.boards[0]?.columns[0]?.cards[0]
+    );
+  });
+});

--- a/stores/boards.ts
+++ b/stores/boards.ts
@@ -23,8 +23,18 @@ import { defineStore } from "pinia";
 import type { Board, Column, Card, Tag } from "@/types/kanban-types";
 import { useTauriStore } from "@/stores/tauriStore";
 import { generateUniqueID } from "@/utils/idGenerator";
+import { aggregateUnifiedTodoItems } from "@/utils/unifiedTodo";
 
 type Pin = { id: string; title: string; pinIcon?: string; pinIconText?: string };
+const AUTO_SAVE_DEBOUNCE_MS = 250;
+
+const addMissingCardIds = (board: Board) => {
+  for (const column of board.columns) {
+    for (const card of column.cards) {
+      if (!card.id) card.id = generateUniqueID();
+    }
+  }
+};
 
 export const useBoardsStore = defineStore("boards", {
   state: () => ({
@@ -35,6 +45,7 @@ export const useBoardsStore = defineStore("boards", {
   getters: {
     boardById: (state) => (id: string) => state.boards.find(b => b.id === id) ?? null,
     isPinned: (state) => (id: string) => !!state.pins.find(p => p.id === id),
+    unifiedTodoItems: (state) => aggregateUnifiedTodoItems(state.boards),
   },
   actions: {
     async init() {
@@ -46,10 +57,12 @@ export const useBoardsStore = defineStore("boards", {
       this.initialized = true;
 
       this._setupAutoSave();
+      this.boards.forEach(addMissingCardIds);
     },
     async forceReloadBoards() {
       const tauri = useTauriStore().store;
       this.boards = (await tauri.get("boards")) || [];
+      this.boards.forEach(addMissingCardIds);
     },
     async save() {
       const tauri = useTauriStore().store;
@@ -67,6 +80,7 @@ export const useBoardsStore = defineStore("boards", {
     // Board CRUD
     upsertBoard(board: Board) {
       const i = this.boards.findIndex(b => b.id === board.id);
+      addMissingCardIds(board);
       board.lastEdited = new Date();
 
       if (i === -1) {
@@ -251,6 +265,19 @@ export const useBoardsStore = defineStore("boards", {
       col.title = title;
       b.lastEdited = new Date();
     },
+    setColumnUnifiedTodoInclusion(
+      boardId: string,
+      columnId: string,
+      include: boolean
+    ) {
+      const b = this.boardById(boardId);
+      if (!b) return;
+      const col = b.columns.find(c => c.id === columnId);
+      if (!col) return;
+
+      col.includeInUnifiedTodo = include;
+      b.lastEdited = new Date();
+    },
     updateColumn(boardId: string, column: Column) {
       const b = this.boardById(boardId);
       if (!b) return;
@@ -350,12 +377,25 @@ export const useBoardsStore = defineStore("boards", {
       if (!sourceCol || !targetCol) return;
 
       const cardIndex = sourceCol.cards.findIndex(c => c.id === cardId);
+      if (cardIndex === -1) return;
 
       const [card] = sourceCol.cards.splice(cardIndex, 1);
       if (card === undefined) return;
       targetCol.cards.push(card);
       targetBoard.lastEdited = new Date();
       sourceBoard.lastEdited = new Date();
+    },
+    moveCardToNextColumn(boardId: string, columnId: string, cardId: string) {
+      const board = this.boardById(boardId);
+      if (!board) return;
+
+      const columnIndex = board.columns.findIndex(column => column.id === columnId);
+      if (columnIndex === -1) return;
+
+      const nextColumn = board.columns[columnIndex + 1];
+      if (!nextColumn) return;
+
+      this.moveCard(boardId, boardId, columnId, nextColumn.id, cardId);
     },
 
     // Debounced auto-save of board properties
@@ -365,12 +405,11 @@ export const useBoardsStore = defineStore("boards", {
       const schedule = () => {
         if (timeout) clearTimeout(timeout);
         timeout = setTimeout(() => {
-          console.log("Auto-saving boards...");
           this.save().catch((err) => {
             console.error("Auto-save failed:", err);
           });
           timeout = null;
-        }, 100);
+        }, AUTO_SAVE_DEBOUNCE_MS);
       };
 
       this.$subscribe(schedule, { detached: true, deep: true});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,12 +27,12 @@ module.exports = {
       },
       animation: {
         slideDownAndFade:
-          "slideDownAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+          "slideDownAndFade 160ms cubic-bezier(0, 0.4, 0, 1)",
         slideLeftAndFade:
-          "slideLeftAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
-        slideUpAndFade: "slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+          "slideLeftAndFade 160ms cubic-bezier(0, 0.4, 0, 1)",
+        slideUpAndFade: "slideUpAndFade 160ms cubic-bezier(0, 0.4, 0, 1)",
         slideRightAndFade:
-          "slideRightAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+          "slideRightAndFade 160ms cubic-bezier(0, 0.4, 0, 1)",
       },
     },
   },

--- a/types/json-schemas.ts
+++ b/types/json-schemas.ts
@@ -48,6 +48,12 @@ const kanriCardSchema = z.object({
   description: z.string().optional(),
   id: z.string().optional(),
   name: z.string(),
+  scheduledWeekday: z
+    .enum(["Pzt", "Sl", "Çrş", "Prş", "Cum", "Cmt", "Paz"])
+    .optional()
+    .nullable(),
+  sourceTitle: z.string().optional().nullable(),
+  sourceUrl: z.string().optional().nullable(),
   tasks: z
     .array(
       z.object({
@@ -64,6 +70,7 @@ const kanriCardSchema = z.object({
 const kanriColumnSchema = z.object({
   cards: z.array(kanriCardSchema),
   id: z.string(),
+  includeInUnifiedTodo: z.boolean().optional(),
   title: z.string(),
 });
 

--- a/types/kanban-types.d.ts
+++ b/types/kanban-types.d.ts
@@ -38,6 +38,7 @@ export declare interface BackgroundSettings {
 export declare interface Column {
   cards: Array<Card>;
   id: string;
+  includeInUnifiedTodo?: boolean;
   title: string;
 }
 
@@ -54,6 +55,15 @@ export declare interface Tag {
   color?: string | null;
 }
 
+export declare type ScheduledWeekday =
+  | "Pzt"
+  | "Sl"
+  | "Çrş"
+  | "Prş"
+  | "Cum"
+  | "Cmt"
+  | "Paz";
+
 export declare interface Card {
   color?: string;
   description?: string;
@@ -62,6 +72,9 @@ export declare interface Card {
   isDueDateCounterRelative?: boolean;
   isDueDateCompleted?: boolean;
   name: string;
+  scheduledWeekday?: ScheduledWeekday | null;
+  sourceTitle?: string | null;
+  sourceUrl?: string | null;
   tasks?: Array<Task>;
   tags?: Array<Tag> | null;
 }

--- a/utils/boardProgress.spec.ts
+++ b/utils/boardProgress.spec.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { calculateBoardProgress, getProgressColumn } from "./boardProgress";
+
+describe("board progress helper", () => {
+  it("counts done cards over workflow cards including planned and ignores idea columns", () => {
+    const progress = calculateBoardProgress({
+      columns: [
+        { id: "idea", title: "Idea", cards: [{ name: "Idea 1" }, { name: "Idea 2" }] },
+        { id: "backlog", title: "Backlog", cards: [{ name: "Backlog task" }] },
+        { id: "planned", title: "Planned", cards: [{ name: "Planned task" }] },
+        {
+          id: "in-progress",
+          title: "In progress",
+          cards: [{ name: "Current task" }, { name: "Second current task" }],
+        },
+        { id: "blocked", title: "Blocked", cards: [{ name: "Blocked task" }] },
+        {
+          id: "done",
+          title: "Done",
+          cards: [{ name: "Done task 1" }, { name: "Done task 2" }],
+        },
+      ],
+    });
+
+    expect(progress).toEqual({ done: 2, total: 7, percentage: 29 });
+  });
+
+  it("returns zero progress when no workflow columns have cards", () => {
+    expect(
+      calculateBoardProgress({
+        columns: [
+          { id: "idea", title: "Idea", cards: [{ name: "Idea" }] },
+          { id: "planned", title: "Planned", cards: [] },
+        ],
+      })
+    ).toEqual({ done: 0, total: 0, percentage: 0 });
+  });
+
+  it("normalizes common progress column title variants", () => {
+    expect(getProgressColumn(" in_progress ")).toBe("inProgress");
+    expect(getProgressColumn("In-Progress")).toBe("inProgress");
+    expect(getProgressColumn("Planned")).toBe("planned");
+    expect(getProgressColumn("Done")).toBe("done");
+    expect(getProgressColumn("Idea")).toBeNull();
+  });
+});

--- a/utils/boardProgress.ts
+++ b/utils/boardProgress.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Board } from "@/types/kanban-types";
+
+type ProgressColumn = "backlog" | "planned" | "inProgress" | "blocked" | "done";
+
+export type BoardProgress = {
+  done: number;
+  total: number;
+  percentage: number;
+};
+
+const normalizeColumnTitle = (title: string) =>
+  title.trim().toLowerCase().replace(/[\s_-]+/g, " ");
+
+export const getProgressColumn = (
+  title: string
+): ProgressColumn | null => {
+  switch (normalizeColumnTitle(title)) {
+    case "backlog":
+      return "backlog";
+    case "planned":
+      return "planned";
+    case "in progress":
+    case "inprogress":
+      return "inProgress";
+    case "blocked":
+      return "blocked";
+    case "done":
+      return "done";
+    default:
+      return null;
+  }
+};
+
+export const calculateBoardProgress = (
+  board: Pick<Board, "columns"> | null | undefined
+): BoardProgress => {
+  if (!board) return { done: 0, total: 0, percentage: 0 };
+
+  let done = 0;
+  let total = 0;
+
+  for (const column of board.columns) {
+    const progressColumn = getProgressColumn(column.title);
+    if (!progressColumn) continue;
+
+    const cardCount = column.cards.length;
+    total += cardCount;
+
+    if (progressColumn === "done") {
+      done += cardCount;
+    }
+  }
+
+  return {
+    done,
+    total,
+    percentage: total > 0 ? Math.round((done / total) * 100) : 0,
+  };
+};

--- a/utils/globalWorkflow.spec.ts
+++ b/utils/globalWorkflow.spec.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import type { Board, Column } from "@/types/kanban-types";
+import {
+  aggregateGlobalWorkflowItems,
+  findGlobalWorkflowColumnId,
+  getGlobalWorkflowColumn,
+  isGlobalWorkflowBoard,
+} from "./globalWorkflow";
+
+const standardColumns = (overrides: Partial<Column>[] = []): Column[] => {
+  const columns: Column[] = [
+    { id: "idea", title: "Idea", cards: [] },
+    { id: "backlog", title: "Backlog", cards: [] },
+    { id: "planned", title: "Planned", cards: [] },
+    { id: "progress", title: "In Progress", cards: [] },
+    { id: "done", title: "Done", cards: [] },
+    { id: "blocked", title: "Blocked", cards: [] },
+  ];
+
+  return columns.map((column, index) => ({
+    ...column,
+    ...overrides[index],
+  }));
+};
+
+describe("global workflow helper", () => {
+  it("matches the six supported workflow columns", () => {
+    expect(getGlobalWorkflowColumn(" in progress ")).toBe("In Progress");
+    expect(getGlobalWorkflowColumn("IN_PROGRESS")).toBe("In Progress");
+    expect(getGlobalWorkflowColumn("Done")).toBe("Done");
+    expect(getGlobalWorkflowColumn("Review")).toBeNull();
+  });
+
+  it("only includes boards with exactly the standard workflow columns", () => {
+    const standardBoard: Board = {
+      id: "standard",
+      title: "Standard",
+      columns: standardColumns(),
+    };
+    const missingColumnBoard: Board = {
+      id: "missing",
+      title: "Missing",
+      columns: standardColumns().slice(0, 5),
+    };
+    const extraColumnBoard: Board = {
+      id: "extra",
+      title: "Extra",
+      columns: [
+        ...standardColumns(),
+        { id: "review", title: "Review", cards: [] },
+      ],
+    };
+
+    expect(isGlobalWorkflowBoard(standardBoard)).toBe(true);
+    expect(isGlobalWorkflowBoard(missingColumnBoard)).toBe(false);
+    expect(isGlobalWorkflowBoard(extraColumnBoard)).toBe(false);
+  });
+
+  it("aggregates cards into matching global columns and keeps origins", () => {
+    const boards: Board[] = [
+      {
+        id: "work",
+        title: "Work",
+        columns: standardColumns([
+          { cards: [{ id: "idea-task", name: "Idea task" }] },
+          { cards: [{ id: "backlog-task", name: "Backlog task" }] },
+          { cards: [{ id: "planned-task", name: "Planned task" }] },
+        ]),
+      },
+      {
+        id: "ignored",
+        title: "Ignored",
+        columns: [{ id: "todo", title: "To Do", cards: [{ id: "x", name: "X" }] }],
+      },
+    ];
+
+    const groups = aggregateGlobalWorkflowItems(boards);
+
+    expect(groups.Idea.map(item => item.card.id)).toEqual(["idea-task"]);
+    expect(groups.Backlog.map(item => item.card.id)).toEqual(["backlog-task"]);
+    expect(groups.Planned[0]?.boardId).toBe("work");
+    expect(groups.Done).toHaveLength(0);
+  });
+
+  it("finds the board column id for a global workflow target", () => {
+    const board: Board = {
+      id: "work",
+      title: "Work",
+      columns: standardColumns([{ title: "Idea" }, {}, {}, { title: "In progress" }]),
+    };
+
+    expect(findGlobalWorkflowColumnId(board, "In Progress")).toBe("progress");
+    expect(findGlobalWorkflowColumnId(board, "Blocked")).toBe("blocked");
+  });
+});

--- a/utils/globalWorkflow.ts
+++ b/utils/globalWorkflow.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Board, Card } from "@/types/kanban-types";
+
+export const GLOBAL_WORKFLOW_COLUMNS = [
+  "Idea",
+  "Backlog",
+  "Planned",
+  "In Progress",
+  "Done",
+  "Blocked",
+] as const;
+
+export type GlobalWorkflowColumn = (typeof GLOBAL_WORKFLOW_COLUMNS)[number];
+
+export interface GlobalWorkflowItem {
+  boardId: string;
+  boardTitle: string;
+  card: Card;
+  cardOrder: number;
+  columnId: string;
+  columnOrder: number;
+  columnTitle: string;
+  workflowColumn: GlobalWorkflowColumn;
+}
+
+export type GlobalWorkflowGroups = Record<
+  GlobalWorkflowColumn,
+  GlobalWorkflowItem[]
+>;
+
+const NORMALIZED_GLOBAL_WORKFLOW_COLUMNS: Record<string, GlobalWorkflowColumn> = {
+  idea: "Idea",
+  backlog: "Backlog",
+  planned: "Planned",
+  "in progress": "In Progress",
+  inprogress: "In Progress",
+  "in-progress": "In Progress",
+  "in_progress": "In Progress",
+  done: "Done",
+  blocked: "Blocked",
+};
+
+export const normalizeGlobalWorkflowColumnTitle = (title: string) =>
+  title.trim().replace(/\s+/g, " ").toLowerCase();
+
+export const getGlobalWorkflowColumn = (
+  title: string
+): GlobalWorkflowColumn | null => {
+  const normalizedTitle = normalizeGlobalWorkflowColumnTitle(title);
+  return NORMALIZED_GLOBAL_WORKFLOW_COLUMNS[normalizedTitle] ?? null;
+};
+
+export const isGlobalWorkflowBoard = (board: Pick<Board, "columns">) => {
+  if (board.columns.length !== GLOBAL_WORKFLOW_COLUMNS.length) return false;
+
+  const workflowColumns = board.columns.map(column =>
+    getGlobalWorkflowColumn(column.title)
+  );
+
+  if (workflowColumns.some(column => column === null)) return false;
+
+  const columnSet = new Set(workflowColumns);
+  return GLOBAL_WORKFLOW_COLUMNS.every(column => columnSet.has(column));
+};
+
+export const findGlobalWorkflowColumnId = (
+  board: Pick<Board, "columns">,
+  workflowColumn: GlobalWorkflowColumn
+) => {
+  return (
+    board.columns.find(
+      column => getGlobalWorkflowColumn(column.title) === workflowColumn
+    )?.id ?? null
+  );
+};
+
+const createEmptyGlobalWorkflowGroups = (): GlobalWorkflowGroups => {
+  return GLOBAL_WORKFLOW_COLUMNS.reduce((groups, column) => {
+    groups[column] = [];
+    return groups;
+  }, {} as GlobalWorkflowGroups);
+};
+
+export const aggregateGlobalWorkflowItems = (
+  boards: Board[]
+): GlobalWorkflowGroups => {
+  const groups = createEmptyGlobalWorkflowGroups();
+
+  for (const board of boards) {
+    if (!isGlobalWorkflowBoard(board)) continue;
+
+    board.columns.forEach((column, columnOrder) => {
+      const workflowColumn = getGlobalWorkflowColumn(column.title);
+      if (!workflowColumn) return;
+
+      column.cards.forEach((card, cardOrder) => {
+        groups[workflowColumn].push({
+          boardId: board.id,
+          boardTitle: board.title,
+          card,
+          cardOrder,
+          columnId: column.id,
+          columnOrder,
+          columnTitle: column.title,
+          workflowColumn,
+        });
+      });
+    });
+  }
+
+  return groups;
+};

--- a/utils/plannedWeekday.spec.ts
+++ b/utils/plannedWeekday.spec.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  PLANNED_WEEKDAYS,
+  getNextPlannedWeekday,
+  isPlannedColumnTitle,
+  isScheduledWeekday,
+} from "./plannedWeekday";
+
+describe("planned weekday helper", () => {
+  it("activates only for Planned columns", () => {
+    expect(isPlannedColumnTitle("Planned")).toBe(true);
+    expect(isPlannedColumnTitle(" planned ")).toBe(true);
+    expect(isPlannedColumnTitle("Planning")).toBe(false);
+    expect(isPlannedColumnTitle("To Do")).toBe(false);
+  });
+
+  it("cycles through the seven planned weekdays", () => {
+    let weekday = getNextPlannedWeekday(null);
+    expect(weekday).toBe("Pzt");
+
+    for (let index = 1; index < PLANNED_WEEKDAYS.length; index++) {
+      weekday = getNextPlannedWeekday(weekday);
+      expect(weekday).toBe(PLANNED_WEEKDAYS[index]);
+    }
+
+    expect(getNextPlannedWeekday(weekday)).toBe("Pzt");
+  });
+
+  it("recognizes valid saved weekday values", () => {
+    expect(isScheduledWeekday("Çrş")).toBe(true);
+    expect(isScheduledWeekday("Tomorrow")).toBe(false);
+    expect(isScheduledWeekday(null)).toBe(false);
+  });
+});

--- a/utils/plannedWeekday.ts
+++ b/utils/plannedWeekday.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { ScheduledWeekday } from "@/types/kanban-types";
+
+export const PLANNED_WEEKDAYS = [
+  "Pzt",
+  "Sl",
+  "Çrş",
+  "Prş",
+  "Cum",
+  "Cmt",
+  "Paz",
+] as const;
+
+const PLANNED_COLUMN_TITLE = "planned";
+
+const PLANNED_WEEKDAY_STYLES: Record<
+  ScheduledWeekday,
+  { backgroundColor: string; borderColor: string; color: string }
+> = {
+  Pzt: { backgroundColor: "#2563eb", borderColor: "#60a5fa", color: "#ffffff" },
+  Sl: { backgroundColor: "#7c3aed", borderColor: "#a78bfa", color: "#ffffff" },
+  Çrş: { backgroundColor: "#0891b2", borderColor: "#67e8f9", color: "#ffffff" },
+  Prş: { backgroundColor: "#16a34a", borderColor: "#86efac", color: "#ffffff" },
+  Cum: { backgroundColor: "#ca8a04", borderColor: "#fde047", color: "#111827" },
+  Cmt: { backgroundColor: "#ea580c", borderColor: "#fdba74", color: "#ffffff" },
+  Paz: { backgroundColor: "#dc2626", borderColor: "#fca5a5", color: "#ffffff" },
+};
+
+export const isPlannedColumnTitle = (title: string) =>
+  title.trim().toLowerCase() === PLANNED_COLUMN_TITLE;
+
+export const isScheduledWeekday = (
+  value: string | null | undefined
+): value is ScheduledWeekday =>
+  Boolean(value && PLANNED_WEEKDAYS.includes(value as ScheduledWeekday));
+
+export const getNextPlannedWeekday = (
+  current: ScheduledWeekday | null | undefined
+) => {
+  const currentIndex = current == null ? -1 : PLANNED_WEEKDAYS.indexOf(current);
+  const nextIndex = (currentIndex + 1) % PLANNED_WEEKDAYS.length;
+
+  return PLANNED_WEEKDAYS[nextIndex];
+};
+
+export const plannedWeekdayStyleFor = (
+  weekday: ScheduledWeekday | null | undefined
+) => {
+  if (!weekday || !isScheduledWeekday(weekday)) return undefined;
+
+  return PLANNED_WEEKDAY_STYLES[weekday];
+};

--- a/utils/quickAdd.spec.ts
+++ b/utils/quickAdd.spec.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  createQuickAddCard,
+  findQuickAddTargetColumn,
+  isSupportedSourceUrl,
+} from "./quickAdd";
+
+describe("quick add helper", () => {
+  it("targets the Idea column when it exists", () => {
+    const target = findQuickAddTargetColumn({
+      columns: [
+        { id: "backlog", title: "Backlog", cards: [] },
+        { id: "idea", title: "Idea", cards: [] },
+      ],
+    });
+
+    expect(target?.id).toBe("idea");
+  });
+
+  it("falls back to the leftmost column when Idea does not exist", () => {
+    const target = findQuickAddTargetColumn({
+      columns: [
+        { id: "left", title: "Backlog", cards: [] },
+        { id: "done", title: "Done", cards: [] },
+      ],
+    });
+
+    expect(target?.id).toBe("left");
+  });
+
+  it("stores tab title and URL on the created card", () => {
+    const card = createQuickAddCard({
+      title: "Example page",
+      url: " https://example.com/article ",
+    });
+
+    expect(card.name).toBe("Example page");
+    expect(card.sourceTitle).toBe("Example page");
+    expect(card.sourceUrl).toBe("https://example.com/article");
+  });
+
+  it("accepts web URLs only", () => {
+    expect(isSupportedSourceUrl("https://example.com")).toBe(true);
+    expect(isSupportedSourceUrl("http://localhost:3000")).toBe(true);
+    expect(isSupportedSourceUrl(" https://example.com ")).toBe(true);
+    expect(isSupportedSourceUrl("chrome://settings")).toBe(false);
+  });
+});

--- a/utils/quickAdd.ts
+++ b/utils/quickAdd.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Board, Card, Column } from "@/types/kanban-types";
+import { generateUniqueID } from "@/utils/idGenerator";
+
+const normalizeColumnTitle = (title: string) => title.trim().toLowerCase();
+
+export const isIdeaColumn = (column: Column) =>
+  normalizeColumnTitle(column.title) === "idea";
+
+export const findQuickAddTargetColumn = (
+  board: Pick<Board, "columns">
+) => {
+  return board.columns.find(isIdeaColumn) ?? board.columns[0] ?? null;
+};
+
+export const isSupportedSourceUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url.trim());
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const createQuickAddCard = ({
+  title,
+  url,
+}: {
+  title: string;
+  url: string;
+}): Card => {
+  const cleanUrl = url.trim();
+  const cleanTitle = title.trim() || cleanUrl;
+
+  return {
+    id: generateUniqueID(),
+    name: cleanTitle,
+    description: "",
+    color: "",
+    dueDate: null,
+    isDueDateCounterRelative: false,
+    isDueDateCompleted: false,
+    scheduledWeekday: null,
+    sourceTitle: cleanTitle,
+    sourceUrl: cleanUrl,
+    tags: [],
+    tasks: [],
+  };
+};

--- a/utils/sourceLinks.spec.ts
+++ b/utils/sourceLinks.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  getQuickAddPathFromDeepLink,
+  getQuickAddRouteTarget,
+} from "./sourceLinks";
+
+describe("source link helpers", () => {
+  it("converts kanri quick-add deep links into route targets", () => {
+    expect(
+      getQuickAddPathFromDeepLink(
+        "kanri://quick-add?title=Example&url=https%3A%2F%2Fexample.com"
+      )
+    ).toEqual({
+      path: "/quick-add",
+      query: {
+        title: "Example",
+        url: "https://example.com",
+      },
+    });
+  });
+
+  it("ignores unrelated schemes", () => {
+    expect(getQuickAddPathFromDeepLink("https://example.com")).toBeNull();
+  });
+
+  it("converts quick-add payloads into route targets", () => {
+    expect(
+      getQuickAddRouteTarget({
+        title: "Docs",
+        url: "https://example.com/docs",
+      })
+    ).toEqual({
+      path: "/quick-add",
+      query: {
+        title: "Docs",
+        url: "https://example.com/docs",
+      },
+    });
+  });
+});

--- a/utils/sourceLinks.ts
+++ b/utils/sourceLinks.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export const openSourceLink = async (sourceUrl?: string | null) => {
+  if (!sourceUrl) return;
+
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(sourceUrl);
+  } catch {
+    window.open(sourceUrl, "_blank", "noopener,noreferrer");
+  }
+};
+
+export const getQuickAddRouteTarget = ({
+  title,
+  url,
+}: {
+  title?: string | null;
+  url?: string | null;
+}) => ({
+  path: "/quick-add",
+  query: { title: title ?? "", url: url ?? "" },
+});
+
+export const getQuickAddPathFromDeepLink = (rawUrl: string) => {
+  let deepLinkUrl: URL;
+
+  try {
+    deepLinkUrl = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (deepLinkUrl.protocol !== "kanri:") return null;
+
+  const isQuickAdd =
+    deepLinkUrl.hostname === "quick-add" ||
+    deepLinkUrl.pathname.replace(/^\/+/, "") === "quick-add";
+
+  if (!isQuickAdd) return null;
+
+  const title = deepLinkUrl.searchParams.get("title") ?? "";
+  const url = deepLinkUrl.searchParams.get("url") ?? "";
+
+  return getQuickAddRouteTarget({ title, url });
+};

--- a/utils/unifiedTodo.spec.ts
+++ b/utils/unifiedTodo.spec.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import type { Board, Column } from "@/types/kanban-types";
+import {
+  aggregateUnifiedTodoItems,
+  isColumnIncludedInUnifiedTodo,
+  normalizeColumnTitle,
+} from "./unifiedTodo";
+
+const column = (values: Partial<Column> = {}): Column => ({
+  cards: [],
+  id: "column-id",
+  title: "To Do",
+  ...values,
+});
+
+describe("Unified To-Do", () => {
+  it("normalizes supported default column names", () => {
+    expect(normalizeColumnTitle("  TO-DO  ")).toBe("to-do");
+
+    for (const title of ["To Do", "todo", "TO-DO", "Yapılacak", "YAPILACAK"]) {
+      expect(isColumnIncludedInUnifiedTodo(column({ title }))).toBe(true);
+    }
+
+    for (const title of ["Backlog", "This Week", "Doing", "Done", "Completed"]) {
+      expect(isColumnIncludedInUnifiedTodo(column({ title }))).toBe(false);
+    }
+  });
+
+  it("honors explicit inclusion and exclusion overrides", () => {
+    expect(
+      isColumnIncludedInUnifiedTodo(
+        column({ title: "Ready", includeInUnifiedTodo: true })
+      )
+    ).toBe(true);
+    expect(
+      isColumnIncludedInUnifiedTodo(
+        column({ title: "To Do", includeInUnifiedTodo: false })
+      )
+    ).toBe(false);
+  });
+
+  it("aggregates original cards across boards and sorts dated cards first", () => {
+    const boards: Board[] = [
+      {
+        id: "work",
+        title: "Work",
+        columns: [
+          column({
+            id: "work-todo",
+            cards: [
+              { id: "later", name: "Later", dueDate: "2026-06-22" },
+              { id: "sooner", name: "Sooner", dueDate: "2026-06-21" },
+              { id: "undated", name: "Undated" },
+            ],
+          }),
+        ],
+      },
+      {
+        id: "living",
+        title: "Living",
+        columns: [
+          column({
+            id: "living-ready",
+            title: "Ready",
+            includeInUnifiedTodo: true,
+            cards: [{ id: "groceries", name: "Buy groceries" }],
+          }),
+        ],
+      },
+    ];
+
+    const items = aggregateUnifiedTodoItems(boards);
+
+    expect(items.map((item) => item.card.id)).toEqual([
+      "sooner",
+      "later",
+      "undated",
+      "groceries",
+    ]);
+    expect(items[0]?.card).toBe(boards[0]?.columns[0]?.cards[1]);
+  });
+
+  it("drops a card as soon as it moves out of an included column", () => {
+    const task = { id: "task", name: "Move me" };
+    const board: Board = {
+      id: "board",
+      title: "Board",
+      columns: [
+        column({ id: "todo", cards: [task] }),
+        column({ id: "doing", title: "Doing", cards: [] }),
+      ],
+    };
+
+    expect(aggregateUnifiedTodoItems([board])).toHaveLength(1);
+    board.columns[0]?.cards.splice(0, 1);
+    board.columns[1]?.cards.push(task);
+    expect(aggregateUnifiedTodoItems([board])).toHaveLength(0);
+  });
+});

--- a/utils/unifiedTodo.ts
+++ b/utils/unifiedTodo.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Board, Card, Column } from "@/types/kanban-types";
+
+const DEFAULT_UNIFIED_TODO_COLUMN_NAMES = new Set([
+  "to do",
+  "todo",
+  "to-do",
+  "yapılacak",
+  "yapilacak",
+]);
+
+export interface UnifiedTodoItem {
+  boardId: string;
+  boardTitle: string;
+  card: Card;
+  cardOrder: number;
+  columnId: string;
+  columnOrder: number;
+  columnTitle: string;
+}
+
+export const normalizeColumnTitle = (title: string) =>
+  title.trim().toLowerCase();
+
+export const isColumnIncludedInUnifiedTodo = (column: Column) => {
+  if (column.includeInUnifiedTodo !== undefined) {
+    return column.includeInUnifiedTodo;
+  }
+
+  return DEFAULT_UNIFIED_TODO_COLUMN_NAMES.has(
+    normalizeColumnTitle(column.title)
+  );
+};
+
+const dueDateTimestamp = (card: Card) => {
+  if (!card.dueDate) return Number.POSITIVE_INFINITY;
+
+  const timestamp = new Date(card.dueDate).getTime();
+  return Number.isNaN(timestamp) ? Number.POSITIVE_INFINITY : timestamp;
+};
+
+export const aggregateUnifiedTodoItems = (
+  boards: Board[]
+): UnifiedTodoItem[] => {
+  return boards.flatMap((board) => {
+    const items = board.columns.flatMap((column, columnOrder) => {
+      if (!isColumnIncludedInUnifiedTodo(column)) return [];
+
+      return column.cards.map((card, cardOrder) => ({
+        boardId: board.id,
+        boardTitle: board.title,
+        card,
+        cardOrder,
+        columnId: column.id,
+        columnOrder,
+        columnTitle: column.title,
+      }));
+    });
+
+    return items.sort((a, b) => {
+      const firstDueDate = dueDateTimestamp(a.card);
+      const secondDueDate = dueDateTimestamp(b.card);
+
+      if (firstDueDate !== secondDueDate) return firstDueDate - secondDueDate;
+      if (a.columnOrder !== b.columnOrder) {
+        return a.columnOrder - b.columnOrder;
+      }
+
+      return a.cardOrder - b.cardOrder;
+    });
+  });
+};

--- a/utils/weeklyCalendar.spec.ts
+++ b/utils/weeklyCalendar.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { aggregateWeeklyCalendarItems } from "./weeklyCalendar";
+
+describe("weekly calendar helper", () => {
+  it("groups only Planned-column cards by selected weekday", () => {
+    const result = aggregateWeeklyCalendarItems([
+      {
+        id: "work",
+        title: "Work",
+        columns: [
+          { id: "idea", title: "Idea", cards: [{ id: "idea-card", name: "Idea" }] },
+          {
+            id: "planned",
+            title: "Planned",
+            cards: [
+              { id: "monday", name: "Monday task", scheduledWeekday: "Pzt" },
+              { id: "unset", name: "Unscheduled task" },
+            ],
+          },
+          {
+            id: "other-planned",
+            title: "Planning",
+            cards: [{ id: "ignored", name: "Ignored", scheduledWeekday: "Pzt" }],
+          },
+        ],
+      },
+    ]);
+
+    expect(result.scheduled.Pzt.map(item => item.card.id)).toEqual(["monday"]);
+    expect(result.unscheduled.map(item => item.card.id)).toEqual(["unset"]);
+  });
+
+  it("keeps separate scheduled buckets for all weekdays", () => {
+    const result = aggregateWeeklyCalendarItems([
+      {
+        id: "week",
+        title: "Week",
+        columns: [
+          {
+            id: "planned",
+            title: "planned",
+            cards: [
+              { id: "wed", name: "Wednesday task", scheduledWeekday: "Çrş" },
+              { id: "sun", name: "Sunday task", scheduledWeekday: "Paz" },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(result.scheduled.Çrş[0]?.card.id).toBe("wed");
+    expect(result.scheduled.Paz[0]?.card.id).toBe("sun");
+    expect(result.scheduled.Pzt).toHaveLength(0);
+  });
+});

--- a/utils/weeklyCalendar.ts
+++ b/utils/weeklyCalendar.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 trobonox <hello@trobo.dev>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { Board, Card, ScheduledWeekday } from "@/types/kanban-types";
+import {
+  PLANNED_WEEKDAYS,
+  isPlannedColumnTitle,
+  isScheduledWeekday,
+} from "@/utils/plannedWeekday";
+
+export interface WeeklyCalendarItem {
+  boardId: string;
+  boardTitle: string;
+  card: Card;
+  cardOrder: number;
+  columnId: string;
+  columnOrder: number;
+  columnTitle: string;
+}
+
+export type WeeklyCalendarGroups = Record<
+  ScheduledWeekday,
+  WeeklyCalendarItem[]
+>;
+
+const createEmptyWeekdayGroups = (): WeeklyCalendarGroups => {
+  return PLANNED_WEEKDAYS.reduce((groups, weekday) => {
+    groups[weekday] = [];
+    return groups;
+  }, {} as WeeklyCalendarGroups);
+};
+
+export const aggregateWeeklyCalendarItems = (
+  boards: Board[]
+): { scheduled: WeeklyCalendarGroups; unscheduled: WeeklyCalendarItem[] } => {
+  const scheduled = createEmptyWeekdayGroups();
+  const unscheduled: WeeklyCalendarItem[] = [];
+
+  for (const board of boards) {
+    board.columns.forEach((column, columnOrder) => {
+      if (!isPlannedColumnTitle(column.title)) return;
+
+      column.cards.forEach((card, cardOrder) => {
+        const item = {
+          boardId: board.id,
+          boardTitle: board.title,
+          card,
+          cardOrder,
+          columnId: column.id,
+          columnOrder,
+          columnTitle: column.title,
+        };
+
+        if (isScheduledWeekday(card.scheduledWeekday)) {
+          scheduled[card.scheduledWeekday].push(item);
+          return;
+        }
+
+        unscheduled.push(item);
+      });
+    });
+  }
+
+  return { scheduled, unscheduled };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,11 @@
   resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-2.10.1.tgz#57c1bae6114ec33d977eb2b50dfefc25fa84fc93"
   integrity sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==
 
+"@tauri-apps/api@^2.11.0":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-2.11.1.tgz#cd6b13fc26403ca095a02e39ecdbec8048d2872d"
+  integrity sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==
+
 "@tauri-apps/api@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-2.8.0.tgz#0348a2b3ba5982ec67a7d569f329b4a55d7d5f1e"
@@ -2407,6 +2412,13 @@
   integrity sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==
   dependencies:
     "@tauri-apps/api" "^2.8.0"
+
+"@tauri-apps/plugin-deep-link@^2.4.9":
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.9.tgz#ae56d59130380f806b533b3107c3f16654e66a8d"
+  integrity sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==
+  dependencies:
+    "@tauri-apps/api" "^2.11.0"
 
 "@tauri-apps/plugin-dialog@2.6.0":
   version "2.6.0"


### PR DESCRIPTION
## Summary

- add Unified To-Do, weekly calendar, and six-column global workflow views backed by the original board data
- add Planned weekday scheduling, board progress, visible subtask checklists, and source URL support
- add a Chrome quick-add extension with in-popup board selection and a localhost-only Tauri bridge
- refresh the application UI with flatter surfaces, denser headers, subtler navigation, and consistent motion tokens

## Why

Kanri already provides flexible local boards, but planning and reviewing work across multiple boards requires repeatedly switching context. These additions provide synchronized aggregate views while keeping every card connected to its original board and column.

The UI refresh reduces visual noise around these denser workflows and standardizes interaction feedback without changing the existing board operations.

## Implementation notes

- new card fields are optional for backward compatibility
- aggregate views mutate the same Pinia board objects and persist through the existing store
- the quick-add bridge binds only to `127.0.0.1:47827` and restricts browser origins to Chrome extensions
- this is intentionally opened as a draft because the scope is substantial and can be split into workflow, extension, and UI PRs if preferred

## Validation

- `npx vitest run utils/boardProgress.spec.ts utils/globalWorkflow.spec.ts utils/weeklyCalendar.spec.ts utils/quickAdd.spec.ts stores/boards.spec.ts --config ../work/vitest.unified.config.mjs` (17 tests passed)
- `cargo check`
- `npx eslint ... --quiet`
- `yarn generate`
- `git diff --check`
